### PR TITLE
distro: Add `fold` as a host tool

### DIFF
--- a/conf/distro/lkft.conf
+++ b/conf/distro/lkft.conf
@@ -11,5 +11,8 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-generic-mainline"
 IMAGE_FSTYPES_remove = "ext4 iso wic wic.gz"
 RDEPENDS_packagegroup-rpb_remove = "docker"
 
+# `fold' is needed for recent kernels (4.20+)
+HOSTTOOLS += "fold"
+
 # Read kernel parameters for LKFT, if there's any
 include conf/lkft-kernel.conf


### PR DESCRIPTION
Recent kernels (as of 4.20, approx.) require `fold' to be
available in the system:
.../kernel-source/scripts/atomic/atomic-tbl.sh:
   line 183: fold: command not found

That was added by commit "locking/atomics: Add common header
generation files", which reached linux-next around 2018-12-04
and finally landed in mainline.

While there's been attempts to get fold changed for grep (in
the kernel, patching the referred patch) or added in OE
itself, neither patch has reached its final destinatio, so
we're in the need of fixing this at the distro level for
the time being.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>