### PR TITLE
linux: Set -next to nobranch=1

### DIFF
--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -8,7 +8,7 @@ SRCREV_kernel = "8fe28cb58bcb235034b64cbbb7550a8a43fd88be"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
-    git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;branch=master;name=kernel \
+    git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;protocol=https;nobranch=1;name=kernel \
     file://lkft.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \


### PR DESCRIPTION
The linux-next/master tree is updated very often, and is very
unlikely to keep all revisions in the master branch. Setting
the repository to nobranch=1 instead of branch=master can
help in reaching refs built in the past.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>