### PR TITLE
kselftests-next: Drop patch merged upstream

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -10,7 +10,6 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;pro
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
     file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch \
-    file://0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch \
     file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 


### PR DESCRIPTION
Patch:
  0002-selftests-next-seccomp-use-LDLIBS-instead-of-LDFLAGS.patch
is now in linux-next/master.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>