### PR TITLE
ltp: Add preliminary version of LTP 20190115

### DIFF
--- a/recipes-extended/ltp/ltp/0001-open_posix_testsuite-mmap24-2-Relax-condition-a-bit.patch
+++ b/recipes-extended/ltp/ltp/0001-open_posix_testsuite-mmap24-2-Relax-condition-a-bit.patch
@@ -1,0 +1,68 @@
+From 85c972f730e8efe891a06ea3a2dfb5cbbdfbfbf4 Mon Sep 17 00:00:00 2001
+From: "Hongzhi.Song" <hongzhi.song@windriver.com>
+Date: Wed, 10 Oct 2018 22:07:05 -0400
+Subject: [PATCH] open_posix_testsuite/mmap24-2: Relax condition a bit
+
+Mips will return EINVAL instead of ENOMEM as expected
+if the range [addr + len) exceeds TASK_SIZE.
+
+Linux kernel code: arch/mips/mm/mmap.c
+if (flags & MAP_FIXED) {
+    /* Even MAP_FIXED mappings must reside within TASK_SIZE */
+    if (TASK_SIZE - len < addr)
+        return -EINVAL;
+
+Relax the condition and accept both ENOMEM and EINVAL
+as expected outcome.
+
+Upstream-Status: Submitted [https://lists.linux.it/pipermail/ltp/2018-October/009624.html]
+
+Signed-off-by: Hongzhi.Song <hongzhi.song@windriver.com>
+---
+ .../open_posix_testsuite/conformance/interfaces/mmap/24-2.c    | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/testcases/open_posix_testsuite/conformance/interfaces/mmap/24-2.c b/testcases/open_posix_testsuite/conformance/interfaces/mmap/24-2.c
+index de51d43..810e5c8 100644
+--- a/testcases/open_posix_testsuite/conformance/interfaces/mmap/24-2.c
++++ b/testcases/open_posix_testsuite/conformance/interfaces/mmap/24-2.c
+@@ -7,7 +7,7 @@
+  * source tree.
+  *
+  * The mmap() function shall fail if:
+- * [ENOMEM] MAP_FIXED was specified,
++ * [ENOMEM or EINVAL] MAP_FIXED was specified,
+  * and the range [addr,addr+len) exceeds that allowed
+  * for the address space of a process; or, if MAP_FIXED was not specified and
+  * there is insufficient room in the address space to effect the mapping.
+@@ -15,7 +15,7 @@
+  * Test Step:
+  * 1. Map a shared memory object, with size exceeding the value get from
+  *    rlim_cur of resource RLIMIT_AS, setting MAP_FIXED;
+- * 3. Should get ENOMEM.
++ * 3. Should get ENOMEM or EINVAL.
+  */
+ 
+ #include <stdio.h>
+@@ -92,8 +92,8 @@ int main(void)
+ 	       (unsigned long)len);
+ 	pa = mmap(addr, len, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_SHARED, fd,
+ 		  0);
+-	if (pa == MAP_FAILED && errno == ENOMEM) {
+-		printf("Got ENOMEM: %s\nTest PASSED\n", strerror(errno));
++	if (pa == MAP_FAILED && (errno == ENOMEM || errno == EINVAL)) {
++		printf("Got ENOMEM or EINVAL: %s\nTest PASSED\n", strerror(errno));
+ 		exit(PTS_PASS);
+ 	}
+ 
+@@ -102,6 +102,6 @@ int main(void)
+ 	else
+ 		munmap(pa, len);
+ 	close(fd);
+-	printf("Test Fail: Did not get ENOMEM as expected\n");
++	printf("Test Failed: Did not get ENOMEM or EINVAL as expected\n");
+ 	return PTS_FAIL;
+ }
+-- 
+2.8.1
+

--- a/recipes-extended/ltp/ltp/0004-build-Add-option-to-select-libc-implementation.patch
+++ b/recipes-extended/ltp/ltp/0004-build-Add-option-to-select-libc-implementation.patch
@@ -1,0 +1,148 @@
+From 53acddddf1b324e06af886ee4639b774e5c8c8bc Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 7 Jan 2016 18:19:03 +0000
+Subject: [PATCH 04/32] build: Add option to select libc implementation
+
+There are more than glibc for C library implementation available on
+linux now a days, uclibc cloaked like glibc but musl e.g. is very
+different and does not implement all GNU extentions
+
+Disable tests specifically not building _yet_ on musl based systems
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+---
+ Makefile                                    | 5 +++++
+ testcases/kernel/Makefile                   | 5 ++++-
+ testcases/kernel/sched/Makefile             | 4 +++-
+ testcases/kernel/syscalls/Makefile          | 5 +++++
+ testcases/network/nfsv4/acl/Makefile        | 4 ++++
+ testcases/network/rpc/basic_tests/Makefile  | 5 +++++
+ testcases/realtime/func/pi-tests/Makefile   | 4 ++++
+ testcases/realtime/stress/pi-tests/Makefile | 5 +++++
+ 8 files changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 297f8e7..906b280 100644
+--- a/Makefile
++++ b/Makefile
+@@ -49,6 +49,11 @@ SKIP_IDCHECK		?= 0
+ UCLINUX			?= 0
+ export UCLINUX
+ 
++# System C library implementation (glibc,uclibc,musl etc.)
++# default to glibc if not set
++LIBC			?= glibc
++export LIBC
++
+ # CLEAN_TARGETS:	Targets which exist solely in clean.
+ # COMMON_TARGETS:	Targets which exist in all, clean, and install.
+ # INSTALL_TARGETS:	Targets which exist in clean and install (contains
+diff --git a/testcases/kernel/Makefile b/testcases/kernel/Makefile
+index 50a12fa..4f1987f 100644
+--- a/testcases/kernel/Makefile
++++ b/testcases/kernel/Makefile
+@@ -49,12 +49,15 @@ SUBDIRS			+= connectors \
+ 			   logging \
+ 			   mem \
+ 			   numa \
+-			   pty \
+ 			   sched \
+ 			   security \
+ 			   timers \
+ 			   tracing \
+ 
++ifneq ($(LIBC),musl)
++SUBDIRS			+= pty
++endif
++
+ ifeq ($(WITH_POWER_MANAGEMENT_TESTSUITE),yes)
+ SUBDIRS			+= power_management
+ endif
+diff --git a/testcases/kernel/sched/Makefile b/testcases/kernel/sched/Makefile
+index 6245ed0..aa4eb7f 100644
+--- a/testcases/kernel/sched/Makefile
++++ b/testcases/kernel/sched/Makefile
+@@ -23,5 +23,7 @@
+ top_srcdir		?= ../../..
+ 
+ include $(top_srcdir)/include/mk/env_pre.mk
+-
++ifeq ($(LIBC),musl)
++	FILTER_OUT_DIRS += process_stress
++endif
+ include $(top_srcdir)/include/mk/generic_trunk_target.mk
+diff --git a/testcases/kernel/syscalls/Makefile b/testcases/kernel/syscalls/Makefile
+index 8acb395..b749126 100644
+--- a/testcases/kernel/syscalls/Makefile
++++ b/testcases/kernel/syscalls/Makefile
+@@ -28,6 +28,11 @@ ifeq ($(UCLINUX),1)
+ FILTER_OUT_DIRS	+= capget capset chmod chown clone fork getcontext llseek \
+ 		   mincore mprotect nftw profil remap_file_pages sbrk
+ endif
++ifeq ($(LIBC),musl)
++FILTER_OUT_DIRS	+= confstr fmtmsg getcontext ioctl mallopt profil \
++		   rt_sigsuspend setdomainname sethostname sigsuspend \
++		   ustat
++endif
+ 
+ ifeq ($(UCLIBC),1)
+ FILTER_OUT_DIRS	+= profil
+diff --git a/testcases/network/nfsv4/acl/Makefile b/testcases/network/nfsv4/acl/Makefile
+index 8bc78c2..c36cf50 100644
+--- a/testcases/network/nfsv4/acl/Makefile
++++ b/testcases/network/nfsv4/acl/Makefile
+@@ -26,4 +26,8 @@ include $(top_srcdir)/include/mk/env_pre.mk
+ 
+ LDLIBS			+= $(ACL_LIBS)
+ 
++ifeq ($(LIBC),musl)
++FILTER_OUT_MAKE_TARGETS	:= acl1
++endif
++
+ include $(top_srcdir)/include/mk/generic_leaf_target.mk
+diff --git a/testcases/network/rpc/basic_tests/Makefile b/testcases/network/rpc/basic_tests/Makefile
+index 3160813..9bdf5d0 100644
+--- a/testcases/network/rpc/basic_tests/Makefile
++++ b/testcases/network/rpc/basic_tests/Makefile
+@@ -23,4 +23,9 @@
+ top_srcdir		?= ../../../..
+ 
+ include $(top_srcdir)/include/mk/env_pre.mk
++
++ifeq ($(LIBC),musl)
++FILTER_OUT_DIRS += rpc01
++endif
++
+ include $(top_srcdir)/include/mk/generic_trunk_target.mk
+diff --git a/testcases/realtime/func/pi-tests/Makefile b/testcases/realtime/func/pi-tests/Makefile
+index 7a7a57a..5808866 100644
+--- a/testcases/realtime/func/pi-tests/Makefile
++++ b/testcases/realtime/func/pi-tests/Makefile
+@@ -27,5 +27,9 @@ include $(top_srcdir)/include/mk/env_pre.mk
+ include $(abs_srcdir)/../../config.mk
+ 
+ MAKE_TARGETS		:= testpi-0 testpi-1 testpi-2 testpi-4 testpi-5 testpi-6 testpi-7 sbrk_mutex
++ifeq ($(LIBC),musl)
++FILTER_OUT_MAKE_TARGETS	:= testpi-5 testpi-6 sbrk_mutex
++endif
++
+ 
+ include $(top_srcdir)/include/mk/generic_leaf_target.mk
+diff --git a/testcases/realtime/stress/pi-tests/Makefile b/testcases/realtime/stress/pi-tests/Makefile
+index 5edc3b4..aa5987a 100644
+--- a/testcases/realtime/stress/pi-tests/Makefile
++++ b/testcases/realtime/stress/pi-tests/Makefile
+@@ -24,4 +24,9 @@ top_srcdir		?= ../../../..
+ 
+ include $(top_srcdir)/include/mk/env_pre.mk
+ include $(abs_srcdir)/../../config.mk
++
++ifeq ($(LIBC),musl)
++FILTER_OUT_MAKE_TARGETS	:= testpi-3
++endif
++
+ include $(top_srcdir)/include/mk/generic_leaf_target.mk
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0005-kernel-controllers-Link-with-libfts-explicitly-on-mu.patch
+++ b/recipes-extended/ltp/ltp/0005-kernel-controllers-Link-with-libfts-explicitly-on-mu.patch
@@ -1,0 +1,46 @@
+From 6e3058521b50d91d4b0569c4d491c5af5ff798b2 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 7 Jan 2016 18:22:38 +0000
+Subject: [PATCH 05/32] kernel/controllers: Link with libfts explicitly on musl
+
+musl does not implement fts like glibc and therefore it depends on
+external implementation for all fts APIs
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+---
+ testcases/kernel/controllers/Makefile.inc        | 3 +++
+ testcases/kernel/controllers/cpuset/Makefile.inc | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/testcases/kernel/controllers/Makefile.inc b/testcases/kernel/controllers/Makefile.inc
+index b106283..ef5fc0c 100644
+--- a/testcases/kernel/controllers/Makefile.inc
++++ b/testcases/kernel/controllers/Makefile.inc
+@@ -36,6 +36,9 @@ MAKE_DEPS		:= $(LIB)
+ CPPFLAGS		+= -I$(abs_srcdir)/../$(LIBDIR)
+ 
+ LDFLAGS			+= -L$(abs_builddir)/../$(LIBDIR)
++ifeq ($(LIBC),musl)
++LDLIBS			+= -lfts
++endif
+ 
+ INSTALL_TARGETS		?= *.sh
+ 
+diff --git a/testcases/kernel/controllers/cpuset/Makefile.inc b/testcases/kernel/controllers/cpuset/Makefile.inc
+index 9e002f4..e0fcb9c 100644
+--- a/testcases/kernel/controllers/cpuset/Makefile.inc
++++ b/testcases/kernel/controllers/cpuset/Makefile.inc
+@@ -42,6 +42,9 @@ MAKE_DEPS		:= $(LIBCONTROLLERS) $(LIBCPUSET)
+ LDFLAGS			+= -L$(abs_builddir)/$(LIBCPUSET_DIR) -L$(abs_builddir)/$(LIBCONTROLLERS_DIR)
+ 
+ LDLIBS			+= -lcpu_set -lcontrollers -lltp
++ifeq ($(LIBC),musl)
++LDLIBS			+= -lfts
++endif
+ 
+ INSTALL_TARGETS		?= *.sh
+ 
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0007-fix-__WORDSIZE-undeclared-when-building-with-musl.patch
+++ b/recipes-extended/ltp/ltp/0007-fix-__WORDSIZE-undeclared-when-building-with-musl.patch
@@ -1,0 +1,31 @@
+From d1a27570457fb6e1d6bafe81bfa0f3507b137e32 Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Thu, 9 Feb 2017 18:20:58 +0800
+Subject: [PATCH] fix __WORDSIZE undeclared when building with musl
+
+fix __WORDSIZE undeclared when building with musl.
+
+Upstream-Status: Submitted [https://github.com/linux-test-project/ltp/pull/177]
+
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+---
+ include/old/test.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/old/test.h b/include/old/test.h
+index b36764d83..cc6f1b551 100644
+--- a/include/old/test.h
++++ b/include/old/test.h
+@@ -17,6 +17,9 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdint.h>
++#ifndef __GLIBC__
++#include <bits/reg.h>
++#endif
+ 
+ #include "usctest.h"
+ 
+-- 
+2.11.0
+

--- a/recipes-extended/ltp/ltp/0009-fix-redefinition-of-struct-msgbuf-error-building-wit.patch
+++ b/recipes-extended/ltp/ltp/0009-fix-redefinition-of-struct-msgbuf-error-building-wit.patch
@@ -1,0 +1,36 @@
+From bf5dd2932200e0199a38f3028d3bef2253f32e38 Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Thu, 9 Feb 2017 17:17:37 +0800
+Subject: [PATCH] fix redefinition of 'struct msgbuf' error building with musl
+
+When building with musl the file "sys/msg.h" already contain 'struct msgbuf'
+
+Upstream-Status: Submitted [https://github.com/linux-test-project/ltp/pull/177]
+
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+---
+ testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c b/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c
+index a757c0d18..e023114d2 100644
+--- a/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c
++++ b/testcases/kernel/syscalls/ipc/msgrcv/msgrcv08.c
+@@ -47,11 +47,13 @@ const char *TCID = "msgrcv08";
+ const int TST_TOTAL = 1;
+ 
+ #if __WORDSIZE == 32
+-
++#ifdef __GLIBC__
+ struct msgbuf {
+ 	long mtype;     /* message type, must be > 0 */
+ 	char mtext[16]; /* message data */
+ };
++#else
++#endif
+ 
+ static void msr(int msqid)
+ {
+-- 
+2.11.0
+

--- a/recipes-extended/ltp/ltp/0018-guard-mallocopt-with-__GLIBC__.patch
+++ b/recipes-extended/ltp/ltp/0018-guard-mallocopt-with-__GLIBC__.patch
@@ -1,0 +1,33 @@
+From f42b060e80c9f40627c712d4d56d45221bd7d9fa Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 06:51:20 +0000
+Subject: [PATCH 18/32] guard mallocopt() with __GLIBC__
+
+mallocopt is not available on non glibc implementations
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Upstream-Status: Pending
+---
+ utils/benchmark/ebizzy-0.3/ebizzy.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/utils/benchmark/ebizzy-0.3/ebizzy.c b/utils/benchmark/ebizzy-0.3/ebizzy.c
+index 5bb8eff..934d951 100644
+--- a/utils/benchmark/ebizzy-0.3/ebizzy.c
++++ b/utils/benchmark/ebizzy-0.3/ebizzy.c
+@@ -215,10 +215,10 @@ static void read_options(int argc, char *argv[])
+ 			"\"never mmap\" option specified\n");
+ 		usage();
+ 	}
+-
++#ifdef __GLIBC__
+ 	if (never_mmap)
+ 		mallopt(M_MMAP_MAX, 0);
+-
++#endif
+ 	if (chunk_size < record_size) {
+ 		fprintf(stderr, "Chunk size %u smaller than record size %u\n",
+ 			chunk_size, record_size);
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0020-getdents-define-getdents-getdents64-only-for-glibc.patch
+++ b/recipes-extended/ltp/ltp/0020-getdents-define-getdents-getdents64-only-for-glibc.patch
@@ -1,0 +1,50 @@
+From aa3568e6ac28f377e75ce16b11e3c7738a373e53 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 06:57:04 +0000
+Subject: [PATCH 20/32] getdents: define getdents/getdents64 only for glibc
+
+getdents/getdents64 are implemented in musl and when we define static
+functions with same name, it errors out.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ testcases/kernel/syscalls/getdents/getdents.h | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/testcases/kernel/syscalls/getdents/getdents.h b/testcases/kernel/syscalls/getdents/getdents.h
+index abea655..db63d89 100644
+--- a/testcases/kernel/syscalls/getdents/getdents.h
++++ b/testcases/kernel/syscalls/getdents/getdents.h
+@@ -34,12 +34,13 @@ struct linux_dirent {
+ 	char            d_name[];
+ };
+ 
++#ifdef __GLIBC__
+ static inline int
+ getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int size)
+ {
+ 	return ltp_syscall(__NR_getdents, fd, dirp, size);
+ }
+-
++#endif
+ struct linux_dirent64 {
+ 	uint64_t	d_ino;
+ 	int64_t		d_off;
+@@ -48,10 +49,11 @@ struct linux_dirent64 {
+ 	char		d_name[];
+ };
+ 
++#ifdef __GLIBC__
+ static inline int
+ getdents64(unsigned int fd, struct linux_dirent64 *dirp64, unsigned int size)
+ {
+ 	return ltp_syscall(__NR_getdents64, fd, dirp64, size);
+ }
+-
++#endif
+ #endif /* GETDENTS_H */
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0021-Define-_GNU_SOURCE-for-MREMAP_MAYMOVE-definition.patch
+++ b/recipes-extended/ltp/ltp/0021-Define-_GNU_SOURCE-for-MREMAP_MAYMOVE-definition.patch
@@ -1,0 +1,73 @@
+From b216435bb362df10c45f544b78d8c884eaa901fd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 07:01:02 +0000
+Subject: [PATCH 21/32] Define _GNU_SOURCE for MREMAP_MAYMOVE definition
+
+musl guards MREMAP_MAYMOVE with _GNU_SOURCE unlike glibc which uses
+__USE_GNU
+
+Fixes errors like
+error: 'MREMAP_MAYMOVE' undeclared (first use in this function)
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ testcases/kernel/syscalls/mremap/mremap01.c | 4 +++-
+ testcases/kernel/syscalls/mremap/mremap02.c | 2 ++
+ testcases/kernel/syscalls/mremap/mremap03.c | 2 ++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/mremap/mremap01.c b/testcases/kernel/syscalls/mremap/mremap01.c
+index d63d1e4..24ca174 100644
+--- a/testcases/kernel/syscalls/mremap/mremap01.c
++++ b/testcases/kernel/syscalls/mremap/mremap01.c
+@@ -76,10 +76,12 @@
+  */
+ #include <unistd.h>
+ #include <errno.h>
++#include <fcntl.h>
++#define _GNU_SOURCE
+ #define __USE_GNU
+ #include <sys/mman.h>
+ #undef __USE_GNU
+-#include <fcntl.h>
++#undef _GNU_SOURCE
+ 
+ #include "test.h"
+ #include "safe_macros.h"
+diff --git a/testcases/kernel/syscalls/mremap/mremap02.c b/testcases/kernel/syscalls/mremap/mremap02.c
+index 5a51b9a..a530a6b 100644
+--- a/testcases/kernel/syscalls/mremap/mremap02.c
++++ b/testcases/kernel/syscalls/mremap/mremap02.c
+@@ -75,9 +75,11 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#define _GNU_SOURCE
+ #define __USE_GNU
+ #include <sys/mman.h>
+ #undef __USE_GNU
++#undef _GNU_SOURCE
+ 
+ #include "test.h"
+ 
+diff --git a/testcases/kernel/syscalls/mremap/mremap03.c b/testcases/kernel/syscalls/mremap/mremap03.c
+index 12e3829..9b39f8b 100644
+--- a/testcases/kernel/syscalls/mremap/mremap03.c
++++ b/testcases/kernel/syscalls/mremap/mremap03.c
+@@ -76,9 +76,11 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <fcntl.h>
++#define _GNU_SOURCE
+ #define __USE_GNU
+ #include <sys/mman.h>
+ #undef __USE_GNU
++#undef _GNU_SOURCE
+ 
+ #include "test.h"
+ 
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0023-ptrace-Use-int-instead-of-enum-__ptrace_request.patch
+++ b/recipes-extended/ltp/ltp/0023-ptrace-Use-int-instead-of-enum-__ptrace_request.patch
@@ -1,0 +1,50 @@
+From 560347f77236616a635b4a997a0596b8da4d0799 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 07:08:25 +0000
+Subject: [PATCH 23/32] ptrace:  Use int instead of enum __ptrace_request
+
+__ptrace_request is only available with glibc
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ testcases/kernel/syscalls/ptrace/ptrace03.c           | 4 ++++
+ testcases/kernel/syscalls/ptrace/spawn_ptrace_child.h | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/testcases/kernel/syscalls/ptrace/ptrace03.c b/testcases/kernel/syscalls/ptrace/ptrace03.c
+index a4028fc..f1880cd 100644
+--- a/testcases/kernel/syscalls/ptrace/ptrace03.c
++++ b/testcases/kernel/syscalls/ptrace/ptrace03.c
+@@ -102,7 +102,11 @@ static pid_t unused_pid;
+ static pid_t zero_pid;
+ 
+ struct test_case_t {
++#ifdef __GLIBC__
+ 	enum __ptrace_request request;
++#else
++	int request;
++#endif
+ 	pid_t *pid;
+ 	int exp_errno;
+ } test_cases[] = {
+diff --git a/testcases/kernel/syscalls/ptrace/spawn_ptrace_child.h b/testcases/kernel/syscalls/ptrace/spawn_ptrace_child.h
+index ae538e9..85aa89d 100644
+--- a/testcases/kernel/syscalls/ptrace/spawn_ptrace_child.h
++++ b/testcases/kernel/syscalls/ptrace/spawn_ptrace_child.h
+@@ -130,7 +130,11 @@ static char *strings[] = {
+ 	SPT(KILL)
+ 	SPT(SINGLESTEP)
+ };
++#ifdef __GLIBC__
+ static inline char *strptrace(enum __ptrace_request request)
++#else
++static inline char *strptrace(int request)
++#endif
+ {
+ 	return strings[request];
+ }
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0024-rt_sigaction-rt_sigprocmark-Define-_GNU_SOURCE.patch
+++ b/recipes-extended/ltp/ltp/0024-rt_sigaction-rt_sigprocmark-Define-_GNU_SOURCE.patch
@@ -1,0 +1,70 @@
+From e01e9862c248dc90a8ec6f2d06f8469d7a50cd8e Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 07:14:58 +0000
+Subject: [PATCH 24/32] rt_sigaction/rt_sigprocmark: Define _GNU_SOURCE
+
+Fixes musl build failure e.g.
+error: 'SA_NOMASK' undeclared here (not in a function)
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ testcases/kernel/syscalls/rt_sigaction/rt_sigaction01.c     | 1 +
+ testcases/kernel/syscalls/rt_sigaction/rt_sigaction02.c     | 2 +-
+ testcases/kernel/syscalls/rt_sigaction/rt_sigaction03.c     | 1 +
+ testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01.c | 1 +
+ 4 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01.c b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01.c
+index 5cf89cc..bdcb91a 100644
+--- a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01.c
++++ b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01.c
+@@ -28,6 +28,7 @@
+ /*		sigset_t type.                       			      */
+ /******************************************************************************/
+ 
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+diff --git a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02.c b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02.c
+index a1da743..8a27a0f 100644
+--- a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02.c
++++ b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02.c
+@@ -23,7 +23,7 @@
+ /* Description: This tests the rt_sigaction() syscall                         */
+ /*		rt_sigaction Expected EFAULT error check                      */
+ /******************************************************************************/
+-
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+diff --git a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03.c b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03.c
+index 175d220..e7627cd 100644
+--- a/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03.c
++++ b/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03.c
+@@ -24,6 +24,7 @@
+ /*		rt_sigaction Expected EINVAL error check                      */
+ /******************************************************************************/
+ 
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+diff --git a/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01.c b/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01.c
+index 74e5a61..75c57fc 100644
+--- a/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01.c
++++ b/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01.c
+@@ -39,6 +39,7 @@
+ /*		    sigsetsize should indicate the size of a sigset_t type.   */
+ /******************************************************************************/
+ 
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <signal.h>
+ #include <errno.h>
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0026-crash01-Define-_GNU_SOURCE.patch
+++ b/recipes-extended/ltp/ltp/0026-crash01-Define-_GNU_SOURCE.patch
@@ -1,0 +1,31 @@
+From 0133a2b29d6f48d8e2bba6a3be581cdfa91311a6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 07:21:05 +0000
+Subject: [PATCH 26/32] crash01: Define _GNU_SOURCE
+
+Fixes musl build errors like
+error: 'SA_NOMASK' undeclared (first use in this function)
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ testcases/misc/crash/crash01.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/misc/crash/crash01.c b/testcases/misc/crash/crash01.c
+index 0574521..08a02e7 100644
+--- a/testcases/misc/crash/crash01.c
++++ b/testcases/misc/crash/crash01.c
+@@ -49,7 +49,7 @@ stress test at the same time you run other tests, like a multi-user
+ benchmark.
+ 
+ */
+-
++#define _GNU_SOURCE
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-- 
+2.7.0
+

--- a/recipes-extended/ltp/ltp/0028-rt_sigaction.h-Use-sighandler_t-instead-of-__sighand.patch
+++ b/recipes-extended/ltp/ltp/0028-rt_sigaction.h-Use-sighandler_t-instead-of-__sighand.patch
@@ -1,0 +1,48 @@
+From 94557fb7e1293c61145c959b8c5ffecf4a2b1069 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 8 Jan 2016 07:24:44 +0000
+Subject: [PATCH 28/32] rt_sigaction.h: Use sighandler_t instead of
+ __sighandler_t
+
+When _GNU_SOURCE is used then both typedefs are same and using
+sighandler_t makes it work on musl too
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Upstream-Status: Pending
+---
+ include/lapi/rt_sigaction.h                      | 4 ++--
+ testcases/kernel/syscalls/rt_sigsuspend/Makefile | 3 +++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/include/lapi/rt_sigaction.h b/include/lapi/rt_sigaction.h
+index 18236db..15facda 100644
+--- a/include/lapi/rt_sigaction.h
++++ b/include/lapi/rt_sigaction.h
+@@ -36,12 +36,12 @@
+ #if defined(__mips__)
+ struct kernel_sigaction {
+ 	unsigned int sa_flags;
+-	__sighandler_t k_sa_handler;
++	sighandler_t k_sa_handler;
+ 	sigset_t sa_mask;
+ };
+ #else
+ struct kernel_sigaction {
+-	__sighandler_t k_sa_handler;
++	sighandler_t k_sa_handler;
+ 	unsigned long sa_flags;
+ 	void (*sa_restorer) (void);
+ 	sigset_t sa_mask;
+diff --git a/testcases/kernel/syscalls/rt_sigsuspend/Makefile b/testcases/kernel/syscalls/rt_sigsuspend/Makefile
+index 37bc3a9..2ca7f7c 100644
+--- a/testcases/kernel/syscalls/rt_sigsuspend/Makefile
++++ b/testcases/kernel/syscalls/rt_sigsuspend/Makefile
+@@ -19,4 +19,7 @@
+ top_srcdir		?= ../../../..
+ 
+ include $(top_srcdir)/include/mk/testcases.mk
++
++CFLAGS	+= -D_GNU_SOURCE
++
+ include $(top_srcdir)/include/mk/generic_leaf_target.mk

--- a/recipes-extended/ltp/ltp/0034-periodic_output.patch
+++ b/recipes-extended/ltp/ltp/0034-periodic_output.patch
@@ -1,0 +1,55 @@
+From 5a77e2bdc083f4f842a8ba7c2db1a7ac6e5f0664 Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Wed, 31 May 2017 21:26:05 -0400
+Subject: [PATCH] Add periodic output for long time test.
+
+This is needed in context of having scripts running ltp tests and
+waiting with a timeout for the output of the tests.
+
+Signed-off-by: Tudor Florea <tudor.florea@enea.com>
+Upstream-Status: Pending
+
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+---
+ .../kernel/controllers/memcg/stress/memcg_stress_test.sh      | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh b/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh
+index af1a708..084e628 100755
+--- a/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh
++++ b/testcases/kernel/controllers/memcg/stress/memcg_stress_test.sh
+@@ -37,7 +37,8 @@ if [ "x$(grep -w memory /proc/cgroups | cut -f4)" != "x1" ]; then
+         exit 0
+ fi
+ 
+-RUN_TIME=$(( 15 * 60 ))
++ONE_MINUTE=60
++RUN_TIME=15
+ 
+ cleanup()
+ {
+@@ -62,7 +63,7 @@ do_mount()
+ # $1 - Number of cgroups
+ # $2 - Allocated how much memory in one process? in MB
+ # $3 - The interval to touch memory in a process
+-# $4 - How long does this test run ? in second
++# $4 - How long does this test run ? in minutes
+ run_stress()
+ {
+ 	do_mount;
+@@ -81,7 +82,11 @@ run_stress()
+ 		eval /bin/kill -s SIGUSR1 \$pid$i 2> /dev/null
+ 	done
+ 
+-	sleep $4
++	for i in $(seq 0 $(($4-1)))
++	do
++		eval echo "Started $i min ago. Still alive... "
++		sleep $ONE_MINUTE
++	done
+ 
+ 	for i in $(seq 0 $(($1-1)))
+ 	do
+-- 
+2.8.1
+

--- a/recipes-extended/ltp/ltp/0035-fix-test_proc_kill-hang.patch
+++ b/recipes-extended/ltp/ltp/0035-fix-test_proc_kill-hang.patch
@@ -1,0 +1,32 @@
+From f7c602b639db0d118e07d3fa7b6deead0be0c72b Mon Sep 17 00:00:00 2001
+From: Dengke Du <dengke.du@windriver.com>
+Date: Wed, 8 Feb 2017 16:17:17 +0800
+Subject: [PATCH 3/5] Fix test_proc_kill hanging
+
+Sometimes the signal is delivered to memcg_process before the framework took
+into consideration its pid entered in the tasks. Fixed by delaying the signal
+send command.
+
+Signed-off-by: George Nita <george.nita@enea.com>
+Signed-off-by: Dengke Du <dengke.du@windriver.com>
+
+Upstream-Status: Pending
+---
+ testcases/kernel/controllers/memcg/functional/memcg_lib.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/testcases/kernel/controllers/memcg/functional/memcg_lib.sh b/testcases/kernel/controllers/memcg/functional/memcg_lib.sh
+index b785fe3..2918cc5 100755
+--- a/testcases/kernel/controllers/memcg/functional/memcg_lib.sh
++++ b/testcases/kernel/controllers/memcg/functional/memcg_lib.sh
+@@ -291,6 +291,7 @@ test_proc_kill()
+ 	pid=$!
+ 	TST_CHECKPOINT_WAIT 0
+ 	echo $pid > tasks
++	sleep 1
+ 
+ 	signal_memcg_process $pid $3
+ 
+-- 
+2.7.4
+

--- a/recipes-extended/ltp/ltp/0036-testcases-network-nfsv4-acl-acl1.c-Security-fix-on-s.patch
+++ b/recipes-extended/ltp/ltp/0036-testcases-network-nfsv4-acl-acl1.c-Security-fix-on-s.patch
@@ -1,0 +1,41 @@
+From 672a56be14426eae44864673c6c2afca0ab89d46 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?An=C3=ADbal=20Lim=C3=B3n?= <anibal.limon@linux.intel.com>
+Date: Fri, 13 May 2016 11:11:28 -0500
+Subject: [PATCH] testcases/network/nfsv4/acl/acl1.c: Security fix on string
+ printf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+acl1.c: In function 'test_acl_default':
+acl1.c:317:2: error: format not a string literal and no format arguments
+[-Werror=format-security]
+  printf(cmd);
+
+[YOCTO #9548]
+
+Signed-off-by: Aníbal Limón <anibal.limon@linux.intel.com>
+
+Upstream-Status: Pending
+---
+ testcases/network/nfsv4/acl/acl1.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/testcases/network/nfsv4/acl/acl1.c b/testcases/network/nfsv4/acl/acl1.c
+index b8b67b4..7c7c506 100644
+--- a/testcases/network/nfsv4/acl/acl1.c
++++ b/testcases/network/nfsv4/acl/acl1.c
+@@ -303,7 +303,7 @@ void test_acl_default(char *dir, acl_t acl)
+ 	char *cmd = malloc(256);
+ 
+ 	strcpy(cmd, "chmod 7777 ");
+-	printf(cmd);
++	printf(cmd, NULL);
+ 	strcat(cmd, dir);
+ 	system(cmd);
+ 	acl2 = acl_get_file(path, ACL_TYPE_ACCESS);
+-- 
+2.1.4
+

--- a/recipes-extended/ltp/ltp/0039-commands-ar01-Fix-for-test-in-deterministic-mode.patch
+++ b/recipes-extended/ltp/ltp/0039-commands-ar01-Fix-for-test-in-deterministic-mode.patch
@@ -1,0 +1,254 @@
+From 04da9478887e705ea38e4f097492da20e651686c Mon Sep 17 00:00:00 2001
+From: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+Date: Wed, 13 Sep 2017 15:48:42 +0800
+Subject: [PATCH] commands/ar01: Fix for test in deterministic mode
+
+If binutils was configured with --enable-deterministic-archives,
+ar will run in deterministic mode by default, and use zero for
+timestamps and uids/gids, which makes the test case abnormal.
+
+Fix this by add the "U" modifier when deterministic mode is default.
+
+Signed-off-by: Guangwen Feng <fenggw-fnst@cn.fujitsu.com>
+Signed-off-by: Fei Jie <feij.fnst@cn.fujitsu.com>
+
+Upstream-Status: Backport
+[http://lists.linux.it/pipermail/ltp/2017-September/005668.html]
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ testcases/commands/ar/ar01 | 92 ++++++++++++++++++++++++++--------------------
+ 1 file changed, 52 insertions(+), 40 deletions(-)
+
+diff --git a/testcases/commands/ar/ar01 b/testcases/commands/ar/ar01
+index be105f6da..813a51d9c 100644
+--- a/testcases/commands/ar/ar01
++++ b/testcases/commands/ar/ar01
+@@ -24,16 +24,28 @@
+ #
+ AR="${AR:=ar}"
+ TST_CNT=17
++TST_SETUP=setup
+ TST_TESTFUNC=test
+ TST_NEEDS_TMPDIR=1
+ TST_NEEDS_CMDS="$AR"
+ 
+ . tst_test.sh
+ 
++setup()
++{
++	ar --help | grep "use zero for timestamps and uids/gids (default)" \
++		>/dev/null
++	if [ $? -eq 0 ]; then
++		MOD="U"
++	else
++		MOD=""
++	fi
++}
++
+ test1()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
+-	ROD ar -ra file1.in lib.a $TST_DATAROOT/file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
++	ROD ar -ra"$MOD" file1.in lib.a $TST_DATAROOT/file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -50,9 +62,9 @@ test1()
+ 
+ test2()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-		         $TST_DATAROOT/file3.in $TST_DATAROOT/file4.in
+-	ROD ar -ma file1.in lib.a file4.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in $TST_DATAROOT/file4.in
++	ROD ar -ma"$MOD" file1.in lib.a file4.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile4.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -69,8 +81,8 @@ test2()
+ 
+ test3()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
+-	ROD ar -rb file3.in lib.a $TST_DATAROOT/file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
++	ROD ar -rb"$MOD" file3.in lib.a $TST_DATAROOT/file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -87,9 +99,9 @@ test3()
+ 
+ test4()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
+-	                 $TST_DATAROOT/file2.in
+-	ROD ar -mb file3.in lib.a file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
++			       $TST_DATAROOT/file2.in
++	ROD ar -mb"$MOD" file3.in lib.a file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -106,7 +118,7 @@ test4()
+ 
+ test5()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in \> ar.out
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in \> ar.out
+ 
+ 	if [ -s ar.out ]; then
+ 		tst_res TFAIL "ar produced output unexpectedly (-c)"
+@@ -120,7 +132,7 @@ test5()
+ 
+ test6()
+ {
+-	ROD ar -qc lib.a $TST_DATAROOT/file1.in \> ar.out
++	ROD ar -qc"$MOD" lib.a $TST_DATAROOT/file1.in \> ar.out
+ 
+ 	if [ -s ar.out ]; then
+ 		tst_res TFAIL "ar produced output unexpectedly (-qc)"
+@@ -134,9 +146,9 @@ test6()
+ 
+ test7()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-	                 $TST_DATAROOT/file3.in
+-	ROD ar -d lib.a file1.in file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in
++	ROD ar -d"$MOD" lib.a file1.in file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file3.in\n" > ar.exp
+@@ -153,9 +165,9 @@ test7()
+ 
+ test8()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-	                 $TST_DATAROOT/file3.in
+-	ROD ar -d lib.a
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in
++	ROD ar -d"$MOD" lib.a
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -172,8 +184,8 @@ test8()
+ 
+ test9()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
+-	ROD ar -ri file3.in lib.a $TST_DATAROOT/file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in
++	ROD ar -ri"$MOD" file3.in lib.a $TST_DATAROOT/file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -190,9 +202,9 @@ test9()
+ 
+ test10()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
+-	                 $TST_DATAROOT/file2.in
+-	ROD ar -mi file3.in lib.a file2.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
++			       $TST_DATAROOT/file2.in
++	ROD ar -mi"$MOD" file3.in lib.a file2.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -209,9 +221,9 @@ test10()
+ 
+ test11()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
+-	                 $TST_DATAROOT/file2.in
+-	ROD ar -m lib.a file3.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file3.in \
++			       $TST_DATAROOT/file2.in
++	ROD ar -m"$MOD" lib.a file3.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\n" > ar.exp
+@@ -228,9 +240,9 @@ test11()
+ 
+ test12()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-	                 $TST_DATAROOT/file3.in
+-	ROD ar -p lib.a \> ar.out
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in
++	ROD ar -p"$MOD" lib.a \> ar.out
+ 
+ 	printf "This is file one\nThis is file two\nThis is file three\n" > ar.exp
+ 
+@@ -247,9 +259,9 @@ test12()
+ test13()
+ {
+ 
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-	                 $TST_DATAROOT/file3.in
+-	ROD ar -q lib.a $TST_DATAROOT/file4.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in
++	ROD ar -q"$MOD" lib.a $TST_DATAROOT/file4.in
+ 	ROD ar -t lib.a \> ar.out
+ 
+ 	printf "file1.in\nfile2.in\nfile3.in\nfile4.in\n" > ar.exp
+@@ -267,14 +279,14 @@ test13()
+ test14()
+ {
+ 	ROD touch file0.in
+-	ROD ar -cr lib.a file0.in $TST_DATAROOT/file1.in
++	ROD ar -cr"$MOD" lib.a file0.in $TST_DATAROOT/file1.in
+ 
+ 	file0_mtime1=$(ar -tv lib.a | grep file0.in)
+ 	file1_mtime1=$(ar -tv lib.a | grep file1.in)
+ 
+ 	touch -c -t $(date --date='next day' +"%Y%m%d%H%M") file0.in
+ 
+-	ROD ar -ru lib.a file0.in $TST_DATAROOT/file1.in
++	ROD ar -ru"$MOD" lib.a file0.in $TST_DATAROOT/file1.in
+ 
+ 	file0_mtime2=$(ar -tv lib.a | grep file0.in)
+ 	file1_mtime2=$(ar -tv lib.a | grep file1.in)
+@@ -296,7 +308,7 @@ test14()
+ 
+ test15()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in
+ 	ROD ar -tv lib.a \> ar.out
+ 
+ 	if grep -q '[rwx-]\{9\} [0-9].*/[0-9].*\s*[0-9].*.*file1.in' ar.out; then
+@@ -311,9 +323,9 @@ test15()
+ 
+ test16()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
+-	                 $TST_DATAROOT/file3.in
+-	ROD ar -xv lib.a \> ar.out
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in \
++			       $TST_DATAROOT/file3.in
++	ROD ar -xv"$MOD" lib.a \> ar.out
+ 
+ 	printf "x - file1.in\nx - file2.in\nx - file3.in\n" > ar.exp
+ 
+@@ -335,8 +347,8 @@ test16()
+ 
+ test17()
+ {
+-	ROD ar -cr lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in
+-	ROD ar -xv lib.a file2.in \> ar.out
++	ROD ar -cr"$MOD" lib.a $TST_DATAROOT/file1.in $TST_DATAROOT/file2.in
++	ROD ar -xv"$MOD" lib.a file2.in \> ar.out
+ 
+ 	printf "x - file2.in\n" > ar.exp
+ 
+-- 
+2.19.0.rc2
+

--- a/recipes-extended/ltp/ltp_20190115.bb
+++ b/recipes-extended/ltp/ltp_20190115.bb
@@ -1,0 +1,120 @@
+SUMMARY = "Linux Test Project"
+DESCRIPTION = "The Linux Test Project is a joint project with SGI, IBM, OSDL, and Bull with a goal to deliver test suites to the open source community that validate the reliability, robustness, and stability of Linux. The Linux Test Project is a collection of tools for testing the Linux kernel and related features."
+HOMEPAGE = "http://ltp.sourceforge.net"
+SECTION = "console/utils"
+LICENSE = "GPLv2 & GPLv2+ & LGPLv2+ & LGPLv2.1+ & BSD-2-Clause"
+LIC_FILES_CHKSUM = "\
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://testcases/kernel/controllers/freezer/COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3 \
+    file://testcases/kernel/controllers/freezer/run_freezer.sh;beginline=5;endline=17;md5=86a61d2c042d59836ffb353a21456498 \
+    file://testcases/kernel/hotplug/memory_hotplug/COPYING;md5=e04a2e542b2b8629bf9cd2ba29b0fe41 \
+    file://testcases/kernel/hotplug/cpu_hotplug/COPYING;md5=e04a2e542b2b8629bf9cd2ba29b0fe41 \
+    file://testcases/open_posix_testsuite/COPYING;md5=48b1c5ec633e3e30ec2cf884ae699947 \
+    file://testcases/realtime/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
+    file://utils/benchmark/kernbench-0.42/COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
+    file://utils/ffsb-6.0-rc2/COPYING;md5=c46082167a314d785d012a244748d803 \
+"
+
+DEPENDS = "attr libaio libcap acl openssl zip-native"
+DEPENDS_append_libc-musl = " fts "
+EXTRA_OEMAKE_append_libc-musl = " LIBC=musl "
+
+# since ltp contains x86-64 assembler which uses the frame-pointer register,
+# set -fomit-frame-pointer x86-64 to handle cases where optimisation
+# is set to -O0 or frame pointers have been enabled by -fno-omit-frame-pointer
+# earlier in CFLAGS, etc.
+CFLAGS_append_x86-64 = " -fomit-frame-pointer"
+
+CFLAGS_append_powerpc64 = " -D__SANE_USERSPACE_TYPES__"
+CFLAGS_append_mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
+SRCREV = "0cd0d9ef09f0afb4e7419997a5974f373f32fcec"
+
+SRC_URI = "git://github.com/linux-test-project/ltp.git \
+           file://0004-build-Add-option-to-select-libc-implementation.patch \
+           file://0005-kernel-controllers-Link-with-libfts-explicitly-on-mu.patch \
+           file://0007-fix-__WORDSIZE-undeclared-when-building-with-musl.patch \
+           file://0009-fix-redefinition-of-struct-msgbuf-error-building-wit.patch \
+           file://0018-guard-mallocopt-with-__GLIBC__.patch \
+           file://0020-getdents-define-getdents-getdents64-only-for-glibc.patch \
+           file://0021-Define-_GNU_SOURCE-for-MREMAP_MAYMOVE-definition.patch \
+           file://0023-ptrace-Use-int-instead-of-enum-__ptrace_request.patch \
+           file://0024-rt_sigaction-rt_sigprocmark-Define-_GNU_SOURCE.patch \
+           file://0026-crash01-Define-_GNU_SOURCE.patch \
+           file://0028-rt_sigaction.h-Use-sighandler_t-instead-of-__sighand.patch \
+           file://0034-periodic_output.patch \
+           file://0035-fix-test_proc_kill-hang.patch \
+           file://0036-testcases-network-nfsv4-acl-acl1.c-Security-fix-on-s.patch \
+           file://0039-commands-ar01-Fix-for-test-in-deterministic-mode.patch \
+           file://0001-open_posix_testsuite-mmap24-2-Relax-condition-a-bit.patch \
+           "
+
+S = "${WORKDIR}/git"
+
+inherit autotools-brokensep
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+export prefix = "/opt/ltp"
+export exec_prefix = "/opt/ltp"
+
+PACKAGECONFIG[numa] = "--with-numa, --without-numa, numactl,"
+EXTRA_AUTORECONF += "-I ${S}/testcases/realtime/m4"
+EXTRA_OECONF = " --with-power-management-testsuite --with-realtime-testsuite --with-open-posix-testsuite "
+# ltp network/rpc test cases ftbfs when libtirpc is found
+EXTRA_OECONF += " --without-tirpc "
+
+do_install(){
+    install -d ${D}/opt/ltp/
+    oe_runmake DESTDIR=${D} SKIP_IDCHECK=1 install
+
+    # fixup not deploy STPfailure_report.pl to avoid confusing about it fails to run
+    # as it lacks dependency on some perl moudle such as LWP::Simple
+    # And this script previously works as a tool for analyzing failures from LTP
+    # runs on the OSDL's Scaleable Test Platform (STP) and it mainly accesses
+    # http://khack.osdl.org to retrieve ltp test results run on
+    # OSDL's Scaleable Test Platform, but now http://khack.osdl.org unaccessible
+    rm -rf ${D}/opt/ltp/bin/STPfailure_report.pl
+
+    # Copy POSIX test suite into ${D}/opt/ltp/testcases by manual
+    cp -r testcases/open_posix_testsuite ${D}/opt/ltp/testcases
+}
+
+RDEPENDS_${PN} = "\
+    acl \
+    at \
+    attr \
+    bash \
+    cpio \
+    cronie \
+    curl \
+    e2fsprogs-mke2fs \
+    expect \
+    file \
+    gawk \
+    gzip \
+    iproute2 \
+    ldd \
+    libaio \
+    logrotate \
+    net-tools \
+    perl \
+    python-core \
+    procps \
+    quota \
+    unzip \
+    util-linux \
+    which \
+    tar \
+"
+
+FILES_${PN} += "/opt/ltp/* /opt/ltp/runtest/* /opt/ltp/scenario_groups/* /opt/ltp/testcases/bin/* /opt/ltp/testcases/bin/*/bin/* /opt/ltp/testscripts/* /opt/ltp/testcases/open_posix_testsuite/* /opt/ltp/testcases/open_posix_testsuite/conformance/* /opt/ltp/testcases/open_posix_testsuite/Documentation/* /opt/ltp/testcases/open_posix_testsuite/functional/* /opt/ltp/testcases/open_posix_testsuite/include/* /opt/ltp/testcases/open_posix_testsuite/scripts/* /opt/ltp/testcases/open_posix_testsuite/stress/* /opt/ltp/testcases/open_posix_testsuite/tools/* /opt/ltp/testcases/data/nm01/lib.a /opt/ltp/lib/libmem.a"
+
+# Avoid stripping some generated binaries otherwise some of the ltp tests such as ldd01 & nm01 fail
+INHIBIT_PACKAGE_STRIP_FILES = "/opt/ltp/testcases/bin/nm01 /opt/ltp/testcases/bin/ldd01"
+INSANE_SKIP_${PN} += "already-stripped staticdev"
+
+# Avoid file dependency scans, as LTP checks for things that may or may not
+# exist on the running system.  For instance it has specific checks for
+# csh and ksh which are not typically part of OpenEmbedded systems (but
+# can be added via additional layers.)
+SKIP_FILEDEPS_${PN} = '1'


### PR DESCRIPTION
These patches have been dropped as they have been merged:
* 0001-netns_helper.sh-use-ping-6-when-ping6-is-not-avaliab.patch
* 0001-setrlimit05-Use-another-method-to-get-bad-address.patch
* 0001-sigwaitinfo01-recent-glibc-calls-syscall-directly.patch
* 0001-statx-fix-compile-errors.patch
* 0001-syscalls-fcntl-make-OFD-command-use-fcntl64-syscall-.patch

This requires a lot of rework in order to update it:
* 0008-Check-if-__GLIBC_PREREQ-is-defined-before-using-it.patch

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>