### PR TITLE
kselftests-next: Drop remaining two LDLIBS/LDFLAGS patches

### DIFF
--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -9,8 +9,6 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;pro
 # Some patches may have been submitted to upstream
 SRC_URI += "\
     file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
-    file://0001-selftests-net-use-LDLIBS-instead-of-LDFLAGS-next-20180906.patch \
-    file://0003-selftests-next-timers-use-LDLIBS-instead-of-LDFLAGS.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
As of next-20190129, the patches needed to fix the LDLIBS/
LDFLAGS exchange are now in upstream, so they no longer
required. Hooray!

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>