### PR TITLE
linux: Add three kernel configs to LKFT fragment

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -8,3 +8,10 @@ CONFIG_KSM=y
 # Autogroup
 # https://bugs.linaro.org/show_bug.cgi?id=3377#c0
 CONFIG_SCHED_AUTOGROUP=y
+
+# https://bugs.linaro.org/show_bug.cgi?id=4255
+CONFIG_MEMCG=y
+
+# https://bugs.linaro.org/show_bug.cgi?id=4262
+CONFIG_TASKSTATS=y
+CONFIG_TASK_IO_ACCOUNTING=y


### PR DESCRIPTION
In order to enable a few more LTP tests, these three kernel
configurations need to be enabled. As per bug #4255:
* CONFIG_MEMCG=y
and per bug #4262:
* CONFIG_TASKSTATS=y
* CONFIG_TASK_IO_ACCOUNTING=y

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>