### PR TITLE
ltp: Update to 20190115 proper

### DIFF
--- a/recipes-extended/ltp/ltp_20190115.bb
+++ b/recipes-extended/ltp/ltp_20190115.bb
@@ -27,7 +27,7 @@ CFLAGS_append_x86-64 = " -fomit-frame-pointer"
 
 CFLAGS_append_powerpc64 = " -D__SANE_USERSPACE_TYPES__"
 CFLAGS_append_mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
-SRCREV = "0cd0d9ef09f0afb4e7419997a5974f373f32fcec"
+SRCREV = "a6a5caef13632e669dda27b0461726eba546a2f3"
 
 SRC_URI = "git://github.com/linux-test-project/ltp.git \
            file://0004-build-Add-option-to-select-libc-implementation.patch \


### PR DESCRIPTION
Recently it was discovered that the version reported for LTP
was 20180926-237-g0cd0d9ef0, which is wrong or at least not
what we were expecting.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>