### PR TITLE
linux-generic: Allow for overridable Git protocol

### DIFF
--- a/recipes-kernel/linux/custom-kernel-info.inc
+++ b/recipes-kernel/linux/custom-kernel-info.inc
@@ -1,5 +1,6 @@
 KERNEL_COMMIT = "0adb32858b0bddf4ada5f364a84ed60b196dbcda"
 KERNEL_REPO = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+KERNEL_PROTOCOL = "https"
 KERNEL_BRANCH = "master"
 KERNEL_CONFIG_aarch64 = "defconfig"
 KERNEL_CONFIG_arm = "multi_v7_defconfig"

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -9,7 +9,7 @@ SRCREV_kernel = "${KERNEL_COMMIT}"
 SRCREV_FORMAT = "kernel"
 
 SRC_URI = "\
-    ${KERNEL_REPO};protocol=https;nobranch=1;name=kernel \
+    ${KERNEL_REPO};protocol=${KERNEL_PROTOCOL};nobranch=1;name=kernel \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "


### PR DESCRIPTION
We have forever relied on HTTPS for Git, but the time has come
to use something else, in this case SSH, so let's allow the
protocol for Git to be changed.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>