### PR TITLE
packagegroup: Add perf

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -12,6 +12,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-next \
     libgpiod \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
+    perf \
     tzdata \
     xz \
     "


### PR DESCRIPTION
There's a request to run basic tests using perf in LKFT. (More information on KV-195.)

This adds perf to the LKFT packagegroup, so that perf is shipped with the rpb-console-image-lkft image. Required kernel configs are already in for all boards:
`CONFIG_PERF_EVENTS=y`