### PR TITLE
linux: Fix DB410c DTS issue with recent kernels

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
@@ -112,7 +112,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *sdm845* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* ) || true
 }
 
 require machine-specific-hooks.inc


### PR DESCRIPTION
This is already done in mainline. We remove `*qc404*` from the DTS subdirectory in order to avoid any issues with Skales.