### PR TITLE
packagegroup: Add qemu

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -13,6 +13,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     libgpiod \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     perf \
+    qemu \
     tzdata \
     xz \
     "


### PR DESCRIPTION
There's a request to run KVM tests, which require QEMU with built-in KVM support. This package provides just that. (More information on KV-165.)

This adds qemu to the LKFT packagegroup, so that qemu is shipped with the rpb-console-image-lkft image.