### PR TITLE
Revert "packagegroup: Add perf"

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -12,7 +12,6 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-next \
     libgpiod \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
-    perf \
     qemu \
     tzdata \
     xz \


### PR DESCRIPTION
This reverts commit a24304670fc00791a6c4f859d761d68f4c748c69.

The validation that was previously done was on a bbappend that forced us to use version 4.2, and failed to point to the right license file.

While we resolve all that, it's best to revert this and validate again with the upstream version of perf.