### PR TITLE
Revert "packagegroup: Add qemu"

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -12,7 +12,6 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-next \
     libgpiod \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
-    qemu \
     tzdata \
     xz \
     "


### PR DESCRIPTION
This reverts commit 3f510fbde6f1f53b510f4b39e659cef33147eb4a.

There is a problem with X15 pulling in a few (unavailable) dependencies, such as libgl (from SDL).

Best to fix it for all machines before we deploy it everywhere.