### PR TITLE
Separate linux.inc; fix DB410c kernel+DTB

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux mainline kernel"

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux next kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.14 kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.15 kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.16 LTS kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.17 LTS kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.18 LTS kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.19.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.19.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.19 LTS kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.20 LTS kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.4 kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 4.9 kernel"

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 
 DESCRIPTION = "Generic Linux Stable RC 5.0 LTS kernel"

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -1,4 +1,4 @@
-require linux.inc
+require linux-lkft.inc
 require kselftests.inc
 require custom-kernel-info.inc
 

--- a/recipes-kernel/linux/linux-lkft.inc
+++ b/recipes-kernel/linux/linux-lkft.inc
@@ -25,8 +25,8 @@ python __anonymous () {
     
     devicetree = d.getVar('KERNEL_DEVICETREE', True) or ''
     if devicetree:
-    	depends = d.getVar("DEPENDS", True)
-    	d.setVar("DEPENDS", "%s dtc-native" % depends)
+        depends = d.getVar("DEPENDS", True)
+        d.setVar("DEPENDS", "%s dtc-native" % depends)
 }
 
 do_configure_prepend() {

--- a/recipes-kernel/linux/linux-lkft.inc
+++ b/recipes-kernel/linux/linux-lkft.inc
@@ -196,6 +196,17 @@ do_configure_append() {
 	fi
 }
 
+# append DTB on DB410c
+QCOM_BOOTIMG_BUNDLE_DT = "0"
+do_compile_append_dragonboard-410c() {
+    if ! [ -e ${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} ] ; then
+        oe_runmake ${KERNEL_DEVICETREE}
+    fi
+    cp arch/${ARCH}/boot/${KERNEL_IMAGETYPE} arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup
+    cat arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} > arch/${ARCH}/boot/${KERNEL_IMAGETYPE}
+    rm -f arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup
+}
+
 # bitbake.conf only prepends PARALLEL make in tasks called do_compile, which isn't the case for compile_modules
 # So explicitly enable it for that in here
 EXTRA_OEMAKE = "${PARALLEL_MAKE} "


### PR DESCRIPTION
For DB410c to boot correctly, we need to append the DTB to the kernel.

In order to achieve this without affecting other kernels, we now need to make linux-lkft.inc our own (previously shared  the name with meta-96boards).