### PR TITLE
linux: Add TASK_XACCT to LKFT config fragment

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -15,6 +15,7 @@ CONFIG_MEMCG=y
 # https://bugs.linaro.org/show_bug.cgi?id=4262
 CONFIG_TASKSTATS=y
 CONFIG_TASK_IO_ACCOUNTING=y
+CONFIG_TASK_XACCT=y
 
 # Vivid driver for V4L2 tests
 CONFIG_VIDEO_VIVID=m


### PR DESCRIPTION
Following up on 898cfd7131 ("linux: Add three kernel configs to LKFT fragment"), this kernel configuration was still missing for X15: CONFIG_TASK_XACCT. That will finally enable CONFIG_TASK_IO_ACCOUNTING.

This is needed for bug 4262:
  https://bugs.linaro.org/show_bug.cgi?id=4262