### PR TITLE
linux-lkft: Add DEPENDency on coreutils' realpath

### DIFF
--- a/recipes-kernel/linux/linux-lkft.inc
+++ b/recipes-kernel/linux/linux-lkft.inc
@@ -223,6 +223,7 @@ PACKAGES =+ "${KERNEL_PACKAGE_NAME}-devicetree-overlays"
 FILES_${KERNEL_PACKAGE_NAME}-devicetree-overlays = "/lib/firmware/*.dtbo /lib/firmware/*.dts"
 FILES_${KERNEL_PACKAGE_NAME}-devicetree += "/boot/*.dtb"
 
+DEPENDS += "coreutils-native"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-image_append = " ${KERNEL_PACKAGE_NAME}-devicetree"
 RRECOMMENDS_${KERNEL_PACKAGE_NAME}-image_append = " ${KERNEL_PACKAGE_NAME}-devicetree-overlays"
 


### PR DESCRIPTION
As of next-20190408, an overall simplification of the build system (a series by Masahiro Yamada) requires the use of realpath, from Coreutils, so add it as a dependency on all kernels.