### PR TITLE
libgpiod: add tools and tests to PACKAGECONFIG

### DIFF
--- a/recipes-support/libgpiod/libgpiod_%.bbappend
+++ b/recipes-support/libgpiod/libgpiod_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG = "tools tests"


### PR DESCRIPTION
This is needed for the gpiod-test program.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>