### PR TITLE
linux: kselftests: Install headers into B directory

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -11,6 +11,8 @@ export KST_INSTALL_PATH = "/opt/kselftests/default-in-kernel"
 KSELFTESTS_ARGS = "-i -C ${S}/tools/testing/selftests INSTALL_PATH=${D}${KST_INSTALL_PATH} CC="${CC}" LD="${LD}" ARCH=${ARCH}"
 
 do_compile_append() {
+    export KBUILD_OUTPUT="${B}"
+
     # Make sure to install the user space API used by some tests
     # but not properly declared as a build dependency
     ${MAKE} -C ${S} ARCH=${ARCH} headers_install


### PR DESCRIPTION
A recent commit in the Linux kernel makes a great deal out of "tainted" kernel sources when building out of that directory. In OE's case, the objects are always built elsewhere, not in the kernel source tree itself, so this case applies.

While that is fine for most of the kernel tasks, the append that we have for kselftests means that we run `make headers_install`, which, as it seems, end up in the kernel source tree.

Setting `KBUILD_OUTPUT` before actually installing the headers helps in maintaining that source tree clean.