### PR TITLE
Add qemu to our builds

### DIFF
--- a/conf/distro/lkft.conf
+++ b/conf/distro/lkft.conf
@@ -1,7 +1,7 @@
 require conf/distro/include/rpb.inc
 
 DISTRO_NAME = "Linux-Kernel-Functional-Testing"
-DISTRO_FEATURES_remove = "wayland"
+DISTRO_FEATURES_remove = "opengl wayland"
 
 CMDLINE_remove = "quiet"
 

--- a/conf/distro/lkft.conf
+++ b/conf/distro/lkft.conf
@@ -8,6 +8,8 @@ CMDLINE_remove = "quiet"
 GCCVERSION = "7.%"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-generic-mainline"
+MACHINE_HWCODECS_intel-corei7-64 = ""
+MACHINE_HWCODECS_intel-core2-32 = ""
 IMAGE_FSTYPES_remove = "ext4 iso wic wic.gz"
 RDEPENDS_packagegroup-rpb_remove = "docker"
 

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -13,6 +13,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     libgpiod \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     perf \
+    qemu \
     tzdata \
     xz \
     "


### PR DESCRIPTION
We need to remove a couple of unrelated things, such as opengl distro feature and hardware based codecs for x86, before we can add Qemu to our images (through the LKFT packagegroup), and this series of commits does all that.