### PR TITLE
linux: Assign default info for generic kernel

### DIFF
--- a/recipes-kernel/linux/custom-kernel-info.inc
+++ b/recipes-kernel/linux/custom-kernel-info.inc
@@ -1,7 +1,0 @@
-KERNEL_COMMIT = "0adb32858b0bddf4ada5f364a84ed60b196dbcda"
-KERNEL_REPO = "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
-KERNEL_PROTOCOL = "https"
-KERNEL_BRANCH = "master"
-KERNEL_CONFIG_aarch64 = "defconfig"
-KERNEL_CONFIG_arm = "multi_v7_defconfig"
-KERNEL_CONFIG_x86-64 = "x86_64_defconfig"

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -1,12 +1,19 @@
 require linux-lkft.inc
 require kselftests.inc
-require custom-kernel-info.inc
+include conf/custom-kernel-info.inc
 
 DESCRIPTION = "Generic Linux kernel"
 
 PV = "4.0+git${SRCPV}"
 SRCREV_kernel = "${KERNEL_COMMIT}"
 SRCREV_FORMAT = "kernel"
+
+KERNEL_COMMIT ?= "0adb32858b0bddf4ada5f364a84ed60b196dbcda"
+KERNEL_REPO ?= "git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+KERNEL_PROTOCOL ?= "https"
+KERNEL_CONFIG_aarch64 ?= "defconfig"
+KERNEL_CONFIG_arm ?= "multi_v7_defconfig"
+KERNEL_CONFIG_x86-64 ?= "x86_64_defconfig"
 
 SRC_URI = "\
     ${KERNEL_REPO};protocol=${KERNEL_PROTOCOL};nobranch=1;name=kernel \


### PR DESCRIPTION
This clears the way for the custom-kernel-info to reside in a `conf/` directory, which can be defined by whoever is setting up OE and Bitbake.

Therefore, instead of setting the custom kernel information and placing it inside the layer (Git controlled), that file can now reside under the build `conf/`, along with the `lkft-kernel.conf` and other local configurations.