### PR TITLE
distro: Build EXT4 image for Juno

### DIFF
--- a/conf/distro/lkft.conf
+++ b/conf/distro/lkft.conf
@@ -13,6 +13,10 @@ MACHINE_HWCODECS_intel-core2-32 = ""
 IMAGE_FSTYPES_remove = "ext4 iso wic wic.gz"
 RDEPENDS_packagegroup-rpb_remove = "docker"
 
+# For qemu arm64
+IMAGE_FSTYPES_juno_append = " ext4.gz"
+EXTRA_IMAGECMD_juno_ext4 += " -L rootfs "
+
 # `fold' is needed for recent kernels (4.20+)
 HOSTTOOLS += "fold"
 


### PR DESCRIPTION
We'll use that EXT4 image for Qemu (aarch64) testing.