### PR TITLE
linux: Do not append DTB anymore to Dragonboard 410c's kernel

### DIFF
--- a/recipes-kernel/linux/linux-lkft.inc
+++ b/recipes-kernel/linux/linux-lkft.inc
@@ -197,14 +197,11 @@ do_configure_append() {
 }
 
 # append DTB on DB410c
-QCOM_BOOTIMG_BUNDLE_DT = "0"
+QCOM_BOOTIMG_BUNDLE_DT = "1"
 do_compile_append_dragonboard-410c() {
     if ! [ -e ${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} ] ; then
         oe_runmake ${KERNEL_DEVICETREE}
     fi
-    cp arch/${ARCH}/boot/${KERNEL_IMAGETYPE} arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup
-    cat arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} > arch/${ARCH}/boot/${KERNEL_IMAGETYPE}
-    rm -f arch/${ARCH}/boot/${KERNEL_IMAGETYPE}.backup
 }
 
 # bitbake.conf only prepends PARALLEL make in tasks called do_compile, which isn't the case for compile_modules


### PR DESCRIPTION
Let the QCOM_BOOTIMG_BUNDLE_DT variable do the magic on its own. This leaves a pristine Image.gz, which can be gunzipped withouth any issues (e.g. in LAVA).