### PR TITLE
kselftests: add missing RDEPENDS for test nft_trans_stress.sh

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -38,7 +38,7 @@ FILES_${KERNEL_PACKAGE_NAME}-selftests += "${KST_INSTALL_PATH}/bpf/*.o"
 PACKAGES =+ "kernel-selftests-dbg"
 FILES_${KERNEL_PACKAGE_NAME}-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses perl sudo"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses nftables perl sudo"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "util-linux-uuidgen"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_x86 = " cpupower"


### PR DESCRIPTION
Adding nftables to be able to run nft_trans_stress.sh

\# selftests netfilter nft_trans_stress.sh
netfilter: nft_trans_stress.sh_ #
[SKIP] SKIP Could not run test without nft tool
Could: not_run [SKIP]

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>