### PR TITLE
kselftest: add tool lscpu

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -40,7 +40,7 @@ FILES_${KERNEL_PACKAGE_NAME}-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/
 
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses nftables perl sudo"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
-RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "util-linux-uuidgen"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_x86 = " cpupower"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_x86-64 = " cpupower"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_libc-glibc = " glibc-utils"

--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -34,7 +34,7 @@ FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
 RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses perl sudo"
 RDEPENDS_${PN} =+ "python3-core python3-datetime python3-json python3-pprint"
-RDEPENDS_${PN} =+ "util-linux-uuidgen"
+RDEPENDS_${PN} =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"
 RDEPENDS_${PN}_append_x86-64 = " cpupower"
 RDEPENDS_${PN}_append_libc-glibc = " glibc-utils"

--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -32,7 +32,7 @@ FILES_${PN} = "${INSTALL_PATH}"
 FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses perl sudo"
+RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-tc iputils-ping ncurses nftables perl sudo"
 RDEPENDS_${PN} =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${PN} =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"


### PR DESCRIPTION
When running netfilter nft_trans_stress.sh it complains that it can't
find lscpu

 # selftests netfilter nft_trans_stress.sh
 netfilter: nft_trans_stress.sh_ #
 # ./nft_trans_stress.sh line 52 lscpu command not found
 line: 52_lscpu #

Add util-linux-lscpu to RDEPENDS.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>