### PR TITLE
add an ext4 rootfs to intel

### DIFF
--- a/conf/distro/lkft.conf
+++ b/conf/distro/lkft.conf
@@ -13,6 +13,9 @@ MACHINE_HWCODECS_intel-core2-32 = ""
 IMAGE_FSTYPES_remove = "ext4 iso wic wic.gz"
 RDEPENDS_packagegroup-rpb_remove = "docker"
 
+IMAGE_FSTYPES_intel-corei7-64_append = " ext4.gz"
+IMAGE_FSTYPES_intel-core2-32_append = " ext4.gz"
+
 # For qemu arm64
 IMAGE_FSTYPES_juno_append = " ext4.gz"
 EXTRA_IMAGECMD_juno_ext4 += " -L rootfs "


### PR DESCRIPTION
Would be good to add ext4 so we can boot all qemu jobs the same way.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>