### PR TITLE
perf: Add /scripts to source directory

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -1,0 +1,5 @@
+# As of linux-next-20191022, we need bpf_helpers_doc.py in order to
+# build libbpf, which lives in /scripts. See commit e01a75c159691
+# ("libbpf: Move bpf_{helpers, helper_defs, endian, tracing}.h into
+# libbpf").
+PERF_SRC += "scripts"


### PR DESCRIPTION
Since `next-20191022` (specifically commit e01a75c159691), we need to run `bpf_helpers_doc.py`, which is in the `/scripts` directory of the kernel tree.