### PR TITLE
linux: Drop COMPATIBLE_MACHINE

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.14.bb
@@ -17,7 +17,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.15.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.16.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.17.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.18.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.19.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.19.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.20.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.4.bb
@@ -67,7 +67,6 @@ SRC_URI_append_stih410-b2260 = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_DEVICETREE_remove_juno = "arm/juno-r2.dtb"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\

--- a/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_4.9.bb
@@ -22,7 +22,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "am57xx-evm|beaglebone|dragonboard-410c|hikey|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.0.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.1.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.1.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.2.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.2.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.3.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.3.bb
@@ -16,7 +16,6 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-COMPATIBLE_MACHINE = "hikey|dragonboard-410c|am57xx-evm|beaglebone|intel-core2-32|intel-corei7-64|juno|stih410-b2260"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \


### PR DESCRIPTION
We will be adding NXP's LS2088A soon, and then the Raspberry Pi. It's silly to keep adding those boards to the kernels' list of compatible machines when the kernels are generic.