### PR TITLE
libhugetlbfs: Update dependencies to Python3

### DIFF
--- a/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
+++ b/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
@@ -4,7 +4,7 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LGPL-2.1;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 DEPENDS = "sysfsutils"
-RDEPENDS_${PN} += "bash python python-io python-lang python-subprocess python-resource"
+RDEPENDS_${PN} += "bash python3-core python3-io python3-resource"
 RDEPENDS_${PN}-tests += "bash"
 
 PV = "2.22"


### PR DESCRIPTION
The package is actually using Python3, but that run-time dependency was not declared:
```
ERROR: libhugetlbfs-1_2.22-r0 do_package_qa: QA Issue: /usr/lib/libhugetlbfs/tests/run_tests.py contained in package libhugetlbfs-tests requires /usr/bin/python3, but no providers found in RDEPENDS_libhugetlbfs-tests? [file-rdeps]
ERROR: libhugetlbfs-1_2.22-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: libhugetlbfs-1_2.22-r0 do_package_qa: Function failed: do_package_qa
ERROR: Logfile of failure stored in: /oe/build/tmp/work/.../libhugetlbfs/1_2.22-r0/temp/log.do_package_qa.123
NOTE: recipe libhugetlbfs-1_2.22-r0: task do_package_qa: Failed
ERROR: Task (/oe/build/conf/../../layers/meta-lkft/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb:do_package_qa) failed with exit code '1'
```
Fix this by using the right rdependency, which was not a problem in Sumo, only on Thud and onwards.