### PR TITLE
kselftests-mainline: Upgrade to 5.5

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.5.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.5.patch
@@ -1,0 +1,22 @@
+From 2e93b68257aa88ccdc127ca119304a5f4c76b7c5 Mon Sep 17 00:00:00 2001
+From: Fathi Boudra <fathi.boudra@linaro.org>
+Date: Wed, 22 Mar 2017 17:36:53 +0200
+Subject: [PATCH] selftests: lib: allow to override CC in the top-level Makefile
+
+Relax CC assignment to allow to override CC in the top-level Makefile.
+
+Signed-off-by: Denys Dmytriyenko <denys@ti.com>
+---
+ tools/testing/selftests/lib.mk |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/tools/testing/selftests/lib.mk
++++ b/tools/testing/selftests/lib.mk
+@@ -1,6 +1,6 @@
+ # This mimics the top-level Makefile. We do it explicitly here so that this
+ # Makefile can operate with or without the kbuild infrastructure.
+-CC := $(CROSS_COMPILE)gcc
++CC ?= $(CROSS_COMPILE)gcc
+ 
+ ifeq (0,$(MAKELEVEL))
+     ifeq ($(OUTPUT),)

--- a/recipes-overlayed/kselftests/kselftests-mainline_5.5.bb
+++ b/recipes-overlayed/kselftests/kselftests-mainline_5.5.bb
@@ -6,11 +6,11 @@ SRC_URI = "https://www.kernel.org/pub/linux/kernel/v5.x/linux-${PV}.tar.xz"
 # Patches inappropriate or not yet merged by upstream
 # Some patches may have been submitted to upstream
 SRC_URI += "\
-    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
+    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.5.patch \
 "
 
-SRC_URI[md5sum] = "9905ef7f60b2ad0b26f614d95f3eb1e4"
-SRC_URI[sha256sum] = "e84021a94784de7bb10e4251fb1a87859a8d1c97bd78fb55ad47ab6ce475ec1f"
+SRC_URI[md5sum] = "0a78b1dc48dc032fe505b170c1b92339"
+SRC_URI[sha256sum] = "a6fbd4ee903c128367892c2393ee0d9657b6ed3ea90016d4dc6f1f6da20b2330"
 
 S = "${WORKDIR}/linux-${PV}"
 


### PR DESCRIPTION
Refresh patch to v5.5: `0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.5.patch`.