### PR TITLE
linux: Remove sm8250 from deploy on mainline, next, generic

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -111,7 +111,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* ) || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -111,7 +111,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* ) || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -120,7 +120,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* ) || true
 }
 
 python do_package_prepend() {


### PR DESCRIPTION
As of `next-20200311`, a new Qualcomm board has been added to Linux, which seems problematic when dealing with `dtbTool`. The workaround has been to remove those files before they present any problems, so this is in line with the current behavior.

Currently, only linux-next is affected, but it will eventually reach mainline, and might bite us too if using the generic kernel as that can build any revision whatsoever.