### PR TITLE
libhugetlbfs: Sync 2.22 from meta-oe master

### DIFF
--- a/recipes-benchmark/libhugetlbfs/files/0001-huge_page_setup_helper-use-python3-interpreter.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0001-huge_page_setup_helper-use-python3-interpreter.patch
@@ -1,0 +1,29 @@
+From b77c61de4d88d2c6e5d31f4f5a5877cc4c61272e Mon Sep 17 00:00:00 2001
+From: Andrey Zhizhikin <andrey.z@gmail.com>
+Date: Mon, 27 Jan 2020 17:27:55 +0000
+Subject: [PATCH] huge_page_setup_helper: use python3 interpreter
+
+Setup helper script is already prepared to be used with python3, use the
+interpreter explicitly. This removes dependency to python2 and will not
+fail the QA check.
+
+Upstream-Status: Inappropriate [OE-specific]
+
+Signed-off-by: Andrey Zhizhikin <andrey.z@gmail.com>
+---
+ huge_page_setup_helper.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/huge_page_setup_helper.py b/huge_page_setup_helper.py
+index a9ba2bf..7ba0c92 100755
+--- a/huge_page_setup_helper.py
++++ b/huge_page_setup_helper.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ 
+ #
+ # Tool to set up Linux large page support with minimal effort
+-- 
+2.17.1
+

--- a/recipes-benchmark/libhugetlbfs/files/0001-include-stddef.h-for-ptrdiff_t.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0001-include-stddef.h-for-ptrdiff_t.patch
@@ -4,6 +4,7 @@ Date: Thu, 21 Jun 2018 19:25:57 -0700
 Subject: [PATCH] include stddef.h for ptrdiff_t
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  morecore.c | 1 +
  1 file changed, 1 insertion(+)

--- a/recipes-benchmark/libhugetlbfs/files/0001-run_test.py-not-use-hard-coded-path-.-obj-hugeadm.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0001-run_test.py-not-use-hard-coded-path-.-obj-hugeadm.patch
@@ -9,15 +9,21 @@ After 'make install', we can use hugeadm utility under DESTDIR.
 Upstream-Status: Submitted
 
 Signed-off-by: Ting Liu <b28495@freescale.com>
+
+Update for 2.22.
+Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>
+
+Update to work for python3
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
 ---
- tests/run_tests.py | 13 +++++++++++--
- 1 file changed, 11 insertions(+), 2 deletions(-)
+ tests/run_tests.py | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/tests/run_tests.py b/tests/run_tests.py
-index 018264d..294d7c1 100755
+index 018264d..0aabcd1 100755
 --- a/tests/run_tests.py
 +++ b/tests/run_tests.py
-@@ -245,11 +245,20 @@ def get_pagesizes():
+@@ -245,9 +245,19 @@ def get_pagesizes():
      Use libhugetlbfs' hugeadm utility to get a list of page sizes that have
      active mount points and at least one huge page allocated to the pool.
      """
@@ -26,17 +32,18 @@ index 018264d..294d7c1 100755
      sizes = set()
      out = ""
 -    (rc, out) = bash("../obj/hugeadm --page-sizes")
--    if rc != 0 or out == "":
 +    try:
 +        p = subprocess.Popen("hugeadm --page-sizes", shell=True, env=local_env, stdout=subprocess.PIPE)
 +        rc = p.wait()
 +    except KeyboardInterrupt:
 +        return sizes
 +    except OSError:
-         return sizes
-+    out = p.stdout.read().strip()
++        return sizes
++    out = p.stdout.read().decode().strip()
 +
-+    if rc != 0 or out == "": return sizes
+     if rc != 0 or out == "":
+         return sizes
  
-     for size in out.split("\n"):
-         sizes.add(int(size))
+-- 
+2.7.4
+

--- a/recipes-benchmark/libhugetlbfs/files/0001-tests-add-explicit-permissions-to-open-call.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0001-tests-add-explicit-permissions-to-open-call.patch
@@ -1,0 +1,41 @@
+From d07d2f9601b49bb72cd4b36838f0c238bd1b0fc1 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 15 Jan 2020 18:45:09 -0800
+Subject: [PATCH] tests: add explicit permissions to open() call
+
+Fixes
+gethugepagesizes.c:227:35: error: open with O_CREAT in second argument needs 3 arguments
+|         fd = open(fname, O_WRONLY|O_CREAT);
+|                                          ^
+
+Upstream-Status: Submitted [https://groups.google.com/forum/#!topic/libhugetlbfs/anNtDXbQKro]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ tests/gethugepagesizes.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/gethugepagesizes.c b/tests/gethugepagesizes.c
+index 9551b38..5777265 100644
+--- a/tests/gethugepagesizes.c
++++ b/tests/gethugepagesizes.c
+@@ -223,7 +223,7 @@ void setup_fake_data(long sizes[], int n_elem)
+ 		FAIL("mkdtemp: %s", strerror(errno));
+ 
+ 	sprintf(fname, "%s/meminfo-none", fake_meminfo);
+-	fd = open(fname, O_WRONLY|O_CREAT);
++	fd = open(fname, O_WRONLY|O_CREAT, 0600);
+ 	if (fd < 0)
+ 		FAIL("open: %s", strerror(errno));
+ 	if (write(fd, meminfo_base,
+@@ -233,7 +233,7 @@ void setup_fake_data(long sizes[], int n_elem)
+ 		FAIL("close: %s", strerror(errno));
+ 
+ 	sprintf(fname, "%s/meminfo-hugepages", fake_meminfo);
+-	fd = open(fname, O_WRONLY|O_CREAT);
++	fd = open(fname, O_WRONLY|O_CREAT, 0600);
+ 	if (fd < 0)
+ 		FAIL("open: %s", strerror(errno));
+ 	if (write(fd, meminfo_base,
+-- 
+2.25.0
+

--- a/recipes-benchmark/libhugetlbfs/files/0002-Mark-glibc-specific-code-so.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0002-Mark-glibc-specific-code-so.patch
@@ -4,6 +4,7 @@ Date: Thu, 21 Jun 2018 19:32:59 -0700
 Subject: [PATCH] Mark glibc specific code so
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  morecore.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-benchmark/libhugetlbfs/files/0003-alloc.c-Avoid-sysconf-_SC_LEVEL2_CACHE_LINESIZE-on-l.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0003-alloc.c-Avoid-sysconf-_SC_LEVEL2_CACHE_LINESIZE-on-l.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] alloc.c: Avoid sysconf(_SC_LEVEL2_CACHE_LINESIZE) on linux
 musl does not have it
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  alloc.c | 15 ++++++++++++++-
  1 file changed, 14 insertions(+), 1 deletion(-)

--- a/recipes-benchmark/libhugetlbfs/files/0004-shm.c-Mark-glibc-specific-changes-so.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0004-shm.c-Mark-glibc-specific-changes-so.patch
@@ -4,6 +4,7 @@ Date: Thu, 21 Jun 2018 19:48:04 -0700
 Subject: [PATCH] shm.c: Mark glibc specific changes so
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  shm.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-benchmark/libhugetlbfs/files/0005-Include-dirent.h-for-ino_t.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0005-Include-dirent.h-for-ino_t.patch
@@ -7,19 +7,25 @@ Fixes
 error: unknown type name 'ino_t'; did you mean 'int'?
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Update for 2.22.
+Signed-off-by: Zheng Ruoqin <zhengrq.fnst@cn.fujitsu.com>
 ---
  tests/hugetests.h | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/tests/hugetests.h b/tests/hugetests.h
-index bc4e16a..345d457 100644
+index bc4e16a..fbe4dc0 100644
 --- a/tests/hugetests.h
 +++ b/tests/hugetests.h
-@@ -23,6 +23,7 @@
+@@ -22,6 +22,7 @@
+ 
  #include <errno.h>
  #include <string.h>
- #include <unistd.h>
 +#include <dirent.h>
+ #include <unistd.h>
  
  #include "libhugetlbfs_privutils.h"
- #include "libhugetlbfs_testprobes.h"
+-- 
+2.7.4
+

--- a/recipes-benchmark/libhugetlbfs/files/0006-include-limits.h-for-PATH_MAX.patch
+++ b/recipes-benchmark/libhugetlbfs/files/0006-include-limits.h-for-PATH_MAX.patch
@@ -8,13 +8,14 @@ Fixes
 error: 'PATH_MAX' undeclared
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 ---
  hugeadm.c                | 1 +
  tests/gethugepagesizes.c | 1 +
  2 files changed, 2 insertions(+)
 
 diff --git a/hugeadm.c b/hugeadm.c
-index 79a4867..65d5136 100644
+index fe4211d..8db274c 100644
 --- a/hugeadm.c
 +++ b/hugeadm.c
 @@ -33,6 +33,7 @@

--- a/recipes-benchmark/libhugetlbfs/files/libhugetlbfs-avoid-search-host-library-path-for-cros.patch
+++ b/recipes-benchmark/libhugetlbfs/files/libhugetlbfs-avoid-search-host-library-path-for-cros.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] libhugetlbfs: avoid search host library path for cross
 Upstream-Status: Inappropriate [oe-core specific]
 
 Signed-off-by: Chunrong Guo <B40290@freescale.com>
+
 ---
  ldscripts/elf32ppclinux.xB   | 2 +-
  ldscripts/elf32ppclinux.xBDT | 2 +-

--- a/recipes-benchmark/libhugetlbfs/files/libhugetlbfs-elf_i386-avoid-search-host-library-path.patch
+++ b/recipes-benchmark/libhugetlbfs/files/libhugetlbfs-elf_i386-avoid-search-host-library-path.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] libhugetlbfs/elf_i386: avoid search host library path for
 Upstream-Status: Inappropriate [cross compile specific]
 
 Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+
 ---
  ldscripts/elf_i386.xB   | 1 -
  ldscripts/elf_i386.xBDT | 1 -

--- a/recipes-benchmark/libhugetlbfs/files/skip-checking-LIB32-and-LIB64-if-they-point-to-the-s.patch
+++ b/recipes-benchmark/libhugetlbfs/files/skip-checking-LIB32-and-LIB64-if-they-point-to-the-s.patch
@@ -5,12 +5,13 @@ Subject: [PATCH] skip checking LIB32 and LIB64 if they point to the same place
 
 Upstream-Status: Inappropriate [oe-core specific]
 Signed-off-by: Ting Liu <b28495@freescale.com>
+
 ---
  Makefile | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index a107a62..4ab5323 100644
+index 51e41f0..373df3c 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -177,7 +177,6 @@ REALLIB32 = $(realpath $(PREFIX)/$(LIB32))

--- a/recipes-benchmark/libhugetlbfs/files/tests-Makefile-install-static-4G-edge-testcases.patch
+++ b/recipes-benchmark/libhugetlbfs/files/tests-Makefile-install-static-4G-edge-testcases.patch
@@ -8,6 +8,7 @@ Upstream-Status: Submitted
 TESTS_64 is empty, install will fail due to missing file operand
 
 Signed-off-by: Ting Liu <b28495@freescale.com>
+
 ---
  tests/Makefile | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
+++ b/recipes-benchmark/libhugetlbfs/libhugetlbfs_git.bb
@@ -4,8 +4,8 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://LGPL-2.1;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 DEPENDS = "sysfsutils"
-RDEPENDS_${PN} += "bash python3-core python3-io python3-resource"
-RDEPENDS_${PN}-tests += "bash"
+RDEPENDS_${PN} += "bash python3-core"
+RDEPENDS_${PN}-tests += "bash python3-core"
 
 PV = "2.22"
 PE = "1"
@@ -24,6 +24,8 @@ SRC_URI = " \
     file://0004-shm.c-Mark-glibc-specific-changes-so.patch \
     file://0005-Include-dirent.h-for-ino_t.patch \
     file://0006-include-limits.h-for-PATH_MAX.patch \
+    file://0001-tests-add-explicit-permissions-to-open-call.patch \
+    file://0001-huge_page_setup_helper-use-python3-interpreter.patch \
 "
 
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>\d+(\.\d+)+)"
@@ -36,6 +38,7 @@ LIBARGS = "LIB32=${baselib} LIB64=${baselib}"
 LIBHUGETLBFS_ARCH = "${TARGET_ARCH}"
 LIBHUGETLBFS_ARCH_powerpc = "ppc"
 LIBHUGETLBFS_ARCH_powerpc64 = "ppc64"
+LIBHUGETLBFS_ARCH_powerpc64le = "ppc64"
 EXTRA_OEMAKE = "'ARCH=${LIBHUGETLBFS_ARCH}' 'OPT=${CFLAGS}' 'CC=${CC}' ${LIBARGS} BUILDTYPE=NATIVEONLY V=2"
 PARALLEL_MAKE = ""
 CFLAGS += "-fexpensive-optimizations -frename-registers -fomit-frame-pointer -g0"


### PR DESCRIPTION
Last commit is 70a5edc4b52e ("libhugetlbfs: update recipe to use python3") from meta-openembedded, dated 2020-01-27.

This includes a few Python3 fixes. New patches:
* 0001-huge_page_setup_helper-use-python3-interpreter.patch
* 0001-tests-add-explicit-permissions-to-open-call.patch