### PR TITLE
linux: Enable FANOTIFY config

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -51,8 +51,11 @@ CONFIG_USER_RETURN_NOTIFIER=y
 CONFIG_PREEMPT_NOTIFIERS=y
 CONFIG_IRQ_BYPASS_MANAGER=y
 
-
 # Enable BFQ I/O scheduler
 CONFIG_IOSCHED_BFQ=m
 CONFIG_BFQ_GROUP_IOSCHED=y
 CONFIG_BLK_CGROUP=y
+
+# Enable for arm32/x86 LTP systcalls/fanotify
+# https://bugs.linaro.org/show_bug.cgi?id=5633
+CONFIG_FANOTIFY=y


### PR DESCRIPTION
For LTP syscalls/fanotify tests which are already set in arm64 but not in arm32 nor in i386/x86_64.