### PR TITLE
packagegroups: Add jq

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -7,6 +7,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     git \
     grep \
     haveged \
+    jq \
     kernel-selftests \
     kselftests-mainline \
     kselftests-next \


### PR DESCRIPTION
The jq utility is now needed to parse some JSON results coming out of kselftests' net/forwarding_* tests.