### PR TITLE
linux: Use qcom-bootimg specific hooks for Dragonboard 845c

### DIFF
--- a/recipes-kernel/linux/machine-specific-hooks.inc
+++ b/recipes-kernel/linux/machine-specific-hooks.inc
@@ -3,7 +3,7 @@
 
 def get_include_handler(d):
     machine = d.getVar('MACHINE', True)
-    if (machine == "dragonboard-410c"):
+    if machine in ["dragonboard-410c", "dragonboard-845c"]:
         include = "recipes-kernel/linux/linux-qcom-bootimg.inc"
     else:
         include = "recipes-kernel/linux/file-cannot-be-found.inc"


### PR DESCRIPTION
We are currently using specific boot image hooks when building the kernel for Dragonboard 410c. The same needs to be used for DB845c.