### PR TITLE
ltp: Add net-tools as rdependency

### DIFF
--- a/recipes-extended/ltp/ltp_20200515.bb
+++ b/recipes-extended/ltp/ltp_20200515.bb
@@ -89,6 +89,7 @@ RDEPENDS_${PN} = "\
     ldd \
     libaio \
     logrotate \
+    net-tools \
     perl \
     python3-core \
     procps \


### PR DESCRIPTION
The version of `ifconfig` provided by Busybox is not enough for some tests. Here's an example of how it fails with test netns_breakns_ns_exec_ipv4_ioctl:
```
  ifconfig: bad address '192.168.0.2/24'
  ifconfig: bad address 'inet6'
```
This works with net-tools' `ifconfig`.