### PR TITLE
linux: stable-rc 5.6: Add lkft-crypto config fragment

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable-rc_5.6.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.6.bb
@@ -10,6 +10,7 @@ SRCREV_FORMAT = "kernel"
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git;protocol=https;branch=linux-5.6.y;name=kernel \
     file://lkft.config;subdir=git/kernel/configs \
+    file://lkft-crypto.config;subdir=git/kernel/configs \
     file://distro-overrides.config;subdir=git/kernel/configs \
     file://systemd.config;subdir=git/kernel/configs \
 "
@@ -19,6 +20,7 @@ S = "${WORKDIR}/git"
 KERNEL_IMAGETYPE ?= "Image"
 KERNEL_CONFIG_FRAGMENTS += "\
     ${S}/kernel/configs/lkft.config \
+    ${S}/kernel/configs/lkft-crypto.config \
     ${S}/kernel/configs/distro-overrides.config \
     ${S}/kernel/configs/systemd.config \
 "


### PR DESCRIPTION
This fragment is used in all other kernel versions.