### PR TITLE
ltp: Sync with OE-core from 5/27

### DIFF
--- a/recipes-extended/ltp/ltp_20200515.bb
+++ b/recipes-extended/ltp/ltp_20200515.bb
@@ -72,18 +72,26 @@ do_install(){
          -e 's@[^ ]*-fdebug-prefix-map=[^ "]*@@g' \
          -e 's@[^ ]*-fmacro-prefix-map=[^ "]*@@g' \
          -e 's@[^ ]*--sysroot=[^ "]*@@g' 
+
+    # The controllers memcg_stree test seems to cause us hangs and takes 900s
+    # (maybe we expect more regular output?), anyhow, skip it
+    sed -e '/^memcg_stress/d' -i ${D}${prefix}/runtest/controllers
 }
 
 RDEPENDS_${PN} = "\
     attr \
     bash \
+    bc \
+    coreutils \
     cpio \
     cronie \
     curl \
+    e2fsprogs \
     e2fsprogs-mke2fs \
     expect \
     file \
     gawk \
+    gdb \
     gzip \
     iproute2 \
     ldd \


### PR DESCRIPTION
Add two updates from OE-core master, as of 5/27:
* faa01e1ae7a9 ltp: Add missing dependencies on coreutils, bc, e2fsprogs and gdb
* 0739a8901140 ltp: Exclude the memcg_stress tests due to timeout problems