### PR TITLE
images: Remove X15's limitation for extra rootfs space

### DIFF
--- a/recipes-samples/images/rpb-console-image-lkft.bb
+++ b/recipes-samples/images/rpb-console-image-lkft.bb
@@ -4,10 +4,6 @@ SUMMARY = "Basic console image for LKFT"
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
-# Add 256 MB on X15; more than that might exceed the
-# userdata partition capacity.
-IMAGE_ROOTFS_EXTRA_SPACE_am57xx-evm = "262144"
-
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     packagegroup-rpb-lkft \


### PR DESCRIPTION
As of recently, a change in the partition table of the X15's means that we are now able to use a much larger partition, so this limitation (only adding 256 MB to the rootfs) is not required anymore.