### PR TITLE
v4l-utils: Import 1.18.1 from meta-oe

### DIFF
--- a/recipes-multimedia/v4l2apps/v4l-utils/0001-Revert-media-ctl-Don-t-install-libmediactl-and-libv4.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/0001-Revert-media-ctl-Don-t-install-libmediactl-and-libv4.patch
@@ -1,0 +1,43 @@
+From 67a6e919b8263d6d2b7150e62f26fb06bbc526ef Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 27 Feb 2015 21:55:36 +0000
+Subject: [PATCH] Revert "media-ctl: Don't install libmediactl and
+ libv4l2subdev"
+
+This reverts commit 0911dce53b08b0df3066be2c75f67e8a314d8729.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Conflicts:
+	utils/media-ctl/Makefile.am
+
+---
+ utils/media-ctl/Makefile.am | 10 +++-------
+ 1 file changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/utils/media-ctl/Makefile.am b/utils/media-ctl/Makefile.am
+index ee7dcc9..d11fa2e 100644
+--- a/utils/media-ctl/Makefile.am
++++ b/utils/media-ctl/Makefile.am
+@@ -1,8 +1,7 @@
+-noinst_LTLIBRARIES = libmediactl.la libv4l2subdev.la
+-
++lib_LTLIBRARIES = libmediactl.la libv4l2subdev.la
+ libmediactl_la_SOURCES = libmediactl.c mediactl-priv.h
+-libmediactl_la_CFLAGS = -static $(LIBUDEV_CFLAGS)
+-libmediactl_la_LDFLAGS = -static $(LIBUDEV_LIBS)
++libmediactl_la_CFLAGS = $(LIBUDEV_CFLAGS)
++libmediactl_la_LDFLAGS = $(LIBUDEV_LIBS)
+ 
+ media-bus-format-names.h: ../../include/linux/media-bus-format.h
+ 	sed -e '/#define MEDIA_BUS_FMT/ ! d; s/.*FMT_//; /FIXED/ d; s/\t.*//; s/.*/{ \"&\", MEDIA_BUS_FMT_& },/;' \
+@@ -18,9 +17,6 @@ CLEANFILES = $(BUILT_SOURCES)
+ nodist_libv4l2subdev_la_SOURCES = $(BUILT_SOURCES)
+ libv4l2subdev_la_SOURCES = libv4l2subdev.c
+ libv4l2subdev_la_LIBADD = libmediactl.la
+-libv4l2subdev_la_CFLAGS = -static
+-libv4l2subdev_la_LDFLAGS = -static
+-
+ mediactl_includedir=$(includedir)/mediactl
+ noinst_HEADERS = mediactl.h v4l2subdev.h
+ 

--- a/recipes-multimedia/v4l2apps/v4l-utils/0002-contrib-test-Link-mc_nextgen_test-with-libargp-if-ne.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/0002-contrib-test-Link-mc_nextgen_test-with-libargp-if-ne.patch
@@ -1,0 +1,28 @@
+From 49f865a17d62db7bbd333a9b83fadeea55686e35 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 14 Jul 2017 13:17:19 -0700
+Subject: [PATCH] contrib/test: Link mc_nextgen_test with libargp if needed
+
+musl depends on external argp implementation e.g.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ contrib/test/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/contrib/test/Makefile.am b/contrib/test/Makefile.am
+index 0188fe2..dac07f3 100644
+--- a/contrib/test/Makefile.am
++++ b/contrib/test/Makefile.am
+@@ -40,7 +40,7 @@ sdlcam_CFLAGS = -I../.. $(SDL2_CFLAGS)
+ sdlcam_LDADD = ../../lib/libv4l2/libv4l2.la  ../../lib/libv4lconvert/libv4lconvert.la
+ 
+ mc_nextgen_test_CFLAGS = $(LIBUDEV_CFLAGS)
+-mc_nextgen_test_LDFLAGS = $(LIBUDEV_LIBS)
++mc_nextgen_test_LDFLAGS = $(ARGP_LIBS) $(LIBUDEV_LIBS)
+ 
+ 
+ ioctl_test_SOURCES = ioctl-test.c ioctl-test.h ioctl_32.h ioctl_64.h
+-- 
+2.17.1
+

--- a/recipes-multimedia/v4l2apps/v4l-utils/0005-Define-error_t-and-include-sys-types.h.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/0005-Define-error_t-and-include-sys-types.h.patch
@@ -1,0 +1,45 @@
+From 137ce23ae677b11e5483ef810751edae7bf96bb9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 18:40:06 -0800
+Subject: [PATCH] Define error_t and include sys/types.h
+
+Fix 'unknown type name' for error_t and u_int32_t.
+u_int32_t is defined in sys/type.h
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ utils/ir-ctl/keymap.h   | 4 ++++
+ utils/keytable/keymap.h | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/utils/ir-ctl/keymap.h b/utils/ir-ctl/keymap.h
+index f2b2963..1f8a3f8 100644
+--- a/utils/ir-ctl/keymap.h
++++ b/utils/ir-ctl/keymap.h
+@@ -2,6 +2,10 @@
+ #ifndef __KEYMAP_H
+ #define __KEYMAP_H
+ 
++#include <sys/types.h>
++#ifndef error_t
++typedef int error_t;
++#endif
+ struct keymap {
+ 	struct keymap *next;
+ 	char *name;
+diff --git a/utils/keytable/keymap.h b/utils/keytable/keymap.h
+index f2b2963..345d55d 100644
+--- a/utils/keytable/keymap.h
++++ b/utils/keytable/keymap.h
+@@ -2,6 +2,11 @@
+ #ifndef __KEYMAP_H
+ #define __KEYMAP_H
+ 
++#include <sys/types.h>
++#ifndef error_t
++typedef int error_t;
++#endif
++
+ struct keymap {
+ 	struct keymap *next;
+ 	char *name;

--- a/recipes-multimedia/v4l2apps/v4l-utils/0006-Fix-build-on-32bit-arches-with-64bit-time_t.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/0006-Fix-build-on-32bit-arches-with-64bit-time_t.patch
@@ -1,0 +1,41 @@
+From b213da2d5fcc93cd24fc880c71c717d8e2ce2968 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 18:43:21 -0800
+Subject: [PATCH] Fix build on 32bit arches with 64bit time_t
+
+time element is deprecated on new input_event structure in kernel's
+input.h [1]
+
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ utils/keytable/keytable.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/utils/keytable/keytable.c b/utils/keytable/keytable.c
+index 6cb0217..59ff1ee 100644
+--- a/utils/keytable/keytable.c
++++ b/utils/keytable/keytable.c
+@@ -53,6 +53,11 @@
+ 
+ # define N_(string) string
+ 
++#ifndef input_event_sec
++#define input_event_sec time.tv_sec
++#define input_event_usec time.tv_usec
++#endif
++
+ struct input_keymap_entry_v2 {
+ #define KEYMAP_BY_INDEX	(1 << 0)
+ 	u_int8_t  flags;
+@@ -1533,7 +1538,7 @@ static void test_event(struct rc_device *rc_dev, int fd)
+ 
+ 		for (i = 0; i < rd / sizeof(struct input_event); i++) {
+ 			printf(_("%ld.%06ld: event type %s(0x%02x)"),
+-				ev[i].time.tv_sec, ev[i].time.tv_usec,
++				ev[i].input_event_sec, ev[i].input_event_usec,
+ 				get_event_name(events_type, ev[i].type), ev[i].type);
+ 
+ 			switch (ev[i].type) {

--- a/recipes-multimedia/v4l2apps/v4l-utils/0007-Do-not-use-getsubopt.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/0007-Do-not-use-getsubopt.patch
@@ -1,0 +1,48 @@
+From 4a10eab0e31d69948161241b1801c41201a5d081 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 30 Nov 2019 18:50:34 -0800
+Subject: [PATCH] Do not use getsubopt
+
+POSIX says that behavior when subopts list is empty is undefined.
+musl libs will set value to NULL which leads to crash.
+
+Simply avoid getsubopt, since we cannot rely on it.
+
+Imported from Alpine Linux
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ utils/v4l2-ctl/v4l2-ctl-common.cpp | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/utils/v4l2-ctl/v4l2-ctl-common.cpp b/utils/v4l2-ctl/v4l2-ctl-common.cpp
+index 651917e..cea57b7 100644
+--- a/utils/v4l2-ctl/v4l2-ctl-common.cpp
++++ b/utils/v4l2-ctl/v4l2-ctl-common.cpp
+@@ -782,15 +782,17 @@ static bool parse_subset(char *optarg)
+ 
+ static bool parse_next_subopt(char **subs, char **value)
+ {
+-	static char *const subopts[] = {
+-	    NULL
+-	};
+-	int opt = getsubopt(subs, subopts, value);
++	char *p = *subs;
++	*value = *subs;
+ 
+-	if (opt < 0 || *value)
+-		return false;
+-	fprintf(stderr, "Missing suboption value\n");
+-	return true;
++	while (*p && *p != ',')
++		p++;
++
++	if (*p)
++		*p++ = '\0';
++
++	*subs = p;
++	return false;
+ }
+ 
+ void common_cmd(const std::string &media_bus_info, int ch, char *optarg)

--- a/recipes-multimedia/v4l2apps/v4l-utils/export-mediactl-headers.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/export-mediactl-headers.patch
@@ -1,0 +1,23 @@
+From b82e509c10659a4647961a6da3adf4d285dea2dd Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 1 Mar 2015 22:25:07 +0000
+
+---
+ utils/media-ctl/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/utils/media-ctl/Makefile.am b/utils/media-ctl/Makefile.am
+index 7c520a2..748353d 100644
+--- a/utils/media-ctl/Makefile.am
++++ b/utils/media-ctl/Makefile.am
+@@ -17,8 +17,8 @@ CLEANFILES = $(BUILT_SOURCES)
+ nodist_libv4l2subdev_la_SOURCES = $(BUILT_SOURCES)
+ libv4l2subdev_la_SOURCES = libv4l2subdev.c
+ libv4l2subdev_la_LIBADD = libmediactl.la
+-mediactl_includedir=$(includedir)/mediactl
+-noinst_HEADERS = mediactl.h v4l2subdev.h
++otherincludedir = $(includedir)/mediactl
++otherinclude_HEADERS = mediactl.h v4l2subdev.h
+ 
+ pkgconfig_DATA = libmediactl.pc
+ bin_PROGRAMS = media-ctl

--- a/recipes-multimedia/v4l2apps/v4l-utils/mediactl-pkgconfig.patch
+++ b/recipes-multimedia/v4l2apps/v4l-utils/mediactl-pkgconfig.patch
@@ -1,0 +1,20 @@
+From 480c04ac6a9d11bfef9d4aca073052fdcee4fdea Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 1 Mar 2015 22:25:07 +0000
+
+---
+ utils/media-ctl/Makefile.am | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/media-ctl/Makefile.am b/utils/media-ctl/Makefile.am
+index d11fa2e..7c520a2 100644
+--- a/utils/media-ctl/Makefile.am
++++ b/utils/media-ctl/Makefile.am
+@@ -20,6 +20,7 @@ libv4l2subdev_la_LIBADD = libmediactl.la
+ mediactl_includedir=$(includedir)/mediactl
+ noinst_HEADERS = mediactl.h v4l2subdev.h
+ 
++pkgconfig_DATA = libmediactl.pc
+ bin_PROGRAMS = media-ctl
+ media_ctl_SOURCES = media-ctl.c options.c options.h tools.h
+ media_ctl_LDADD = libmediactl.la libv4l2subdev.la

--- a/recipes-multimedia/v4l2apps/v4l-utils_1.18.1.bb
+++ b/recipes-multimedia/v4l2apps/v4l-utils_1.18.1.bb
@@ -1,0 +1,56 @@
+SUMMARY = "v4l2 and IR applications"
+LICENSE = "GPLv2 & LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=48da9957849056017dc568bbc43d8975 \
+                    file://COPYING.libv4l;md5=d749e86a105281d7a44c2328acebc4b0"
+PROVIDES = "libv4l media-ctl"
+
+DEPENDS = "jpeg \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11', '', d)}"
+DEPENDS_append_libc-musl = " argp-standalone"
+DEPENDS_append_class-target = " udev"
+LDFLAGS_append = " -pthread"
+
+inherit autotools gettext pkgconfig
+
+PACKAGECONFIG ??= "media-ctl"
+PACKAGECONFIG[media-ctl] = "--enable-v4l-utils,--disable-v4l-utils,,"
+
+SRC_URI = "http://linuxtv.org/downloads/v4l-utils/v4l-utils-${PV}.tar.bz2 \
+           file://0001-Revert-media-ctl-Don-t-install-libmediactl-and-libv4.patch \
+           file://mediactl-pkgconfig.patch \
+           file://export-mediactl-headers.patch \
+           file://0002-contrib-test-Link-mc_nextgen_test-with-libargp-if-ne.patch \
+           file://0005-Define-error_t-and-include-sys-types.h.patch \
+           file://0006-Fix-build-on-32bit-arches-with-64bit-time_t.patch \
+           file://0007-Do-not-use-getsubopt.patch \
+           "
+SRC_URI[md5sum] = "ff2dd75970683be9a301ed949b3372b3"
+SRC_URI[sha256sum] = "25fc42253722401f8742f04dc50a444dfa9b75378e7d09b55035bcbb44c5f342"
+
+EXTRA_OECONF = "--disable-qv4l2 --enable-shared --with-udevdir=${base_libdir}/udev"
+
+VIRTUAL-RUNTIME_ir-keytable-keymaps ?= "rc-keymaps"
+
+PACKAGES =+ "media-ctl ir-keytable rc-keymaps libv4l libv4l-dev"
+
+RPROVIDES_${PN}-dbg += "libv4l-dbg"
+
+FILES_media-ctl = "${bindir}/media-ctl ${libdir}/libmediactl.so.*"
+
+FILES_ir-keytable = "${bindir}/ir-keytable ${base_libdir}/udev/rules.d/*-infrared.rules"
+RDEPENDS_ir-keytable += "${VIRTUAL-RUNTIME_ir-keytable-keymaps}"
+
+FILES_rc-keymaps = "${sysconfdir}/rc* ${base_libdir}/udev/rc*"
+
+FILES_${PN} = "${bindir} ${sbindir}"
+
+FILES_libv4l += "${libdir}/libv4l*${SOLIBS} ${libdir}/libv4l/*.so ${libdir}/libv4l/plugins/*.so \
+                 ${libdir}/libdvbv5*${SOLIBS} \
+                 ${libdir}/libv4l/*-decomp"
+
+FILES_libv4l-dev += "${includedir} ${libdir}/pkgconfig \
+                     ${libdir}/libv4l*${SOLIBSDEV} ${libdir}/*.la \
+                     ${libdir}/v4l*${SOLIBSDEV} ${libdir}/libv4l/*.la ${libdir}/libv4l/plugins/*.la"
+
+PARALLEL_MAKE_class-native = ""
+BBCLASSEXTEND = "native"

--- a/recipes-multimedia/v4l2apps/yavta/0001-Add-stdout-mode-to-allow-streaming-over-the-network-.patch
+++ b/recipes-multimedia/v4l2apps/yavta/0001-Add-stdout-mode-to-allow-streaming-over-the-network-.patch
@@ -1,0 +1,961 @@
+From 141d3b3593722eb3d588e7c4b1542f810bc25853 Mon Sep 17 00:00:00 2001
+From: Koen Kooi <koen@dominion.thruhere.net>
+Date: Thu, 5 Jun 2014 11:29:20 -0500
+Subject: [PATCH] Add stdout mode to allow streaming over the network with nc
+
+Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
+Signed-off-by: Chase Maupin <Chase.Maupin@ti.com>
+---
+ yavta.c |  315 ++++++++++++++++++++++++++++++++++-----------------------------
+ 1 file changed, 169 insertions(+), 146 deletions(-)
+
+diff --git a/yavta.c b/yavta.c
+index 32adc26..b398da0 100644
+--- a/yavta.c
++++ b/yavta.c
+@@ -309,7 +309,7 @@ static bool video_has_fd(struct device *dev)
+ static int video_set_fd(struct device *dev, int fd)
+ {
+ 	if (video_has_fd(dev)) {
+-		printf("Can't set fd (already open).\n");
++		fprintf(stderr, "Can't set fd (already open).\n");
+ 		return -1;
+ 	}
+ 
+@@ -321,18 +321,18 @@ static int video_set_fd(struct device *dev, int fd)
+ static int video_open(struct device *dev, const char *devname)
+ {
+ 	if (video_has_fd(dev)) {
+-		printf("Can't open device (already open).\n");
++		fprintf(stderr, "Can't open device (already open).\n");
+ 		return -1;
+ 	}
+ 
+ 	dev->fd = open(devname, O_RDWR);
+ 	if (dev->fd < 0) {
+-		printf("Error opening device %s: %s (%d).\n", devname,
++		fprintf(stderr, "Error opening device %s: %s (%d).\n", devname,
+ 		       strerror(errno), errno);
+ 		return dev->fd;
+ 	}
+ 
+-	printf("Device %s opened.\n", devname);
++	fprintf(stderr, "Device %s opened.\n", devname);
+ 
+ 	dev->opened = 1;
+ 
+@@ -352,7 +352,7 @@ static int video_querycap(struct device *dev, unsigned int *capabilities)
+ 	*capabilities = cap.capabilities & V4L2_CAP_DEVICE_CAPS
+ 		     ? cap.device_caps : cap.capabilities;
+ 
+-	printf("Device `%s' on `%s' is a video %s (%s mplanes) device.\n",
++	fprintf(stderr, "Device `%s' on `%s' is a video %s (%s mplanes) device.\n",
+ 		cap.card, cap.bus_info,
+ 		video_is_capture(dev) ? "capture" : "output",
+ 		video_is_mplane(dev) ? "with" : "without");
+@@ -370,7 +370,7 @@ static int cap_get_buf_type(unsigned int capabilities)
+ 	} else if (capabilities & V4L2_CAP_VIDEO_OUTPUT) {
+ 		return V4L2_BUF_TYPE_VIDEO_OUTPUT;
+ 	} else {
+-		printf("Device supports neither capture nor output.\n");
++		fprintf(stderr, "Device supports neither capture nor output.\n");
+ 		return -EINVAL;
+ 	}
+ 
+@@ -440,7 +440,7 @@ static int get_control(struct device *dev, unsigned int id, int type,
+ 		}
+ 	}
+ 
+-	printf("unable to get control 0x%8.8x: %s (%d).\n",
++	fprintf(stderr, "unable to get control 0x%8.8x: %s (%d).\n",
+ 		id, strerror(errno), errno);
+ 	return -1;
+ }
+@@ -484,12 +484,12 @@ static void set_control(struct device *dev, unsigned int id, int type,
+ 			val = old.value;
+ 	}
+ 	if (ret == -1) {
+-		printf("unable to set control 0x%8.8x: %s (%d).\n",
++		fprintf(stderr, "unable to set control 0x%8.8x: %s (%d).\n",
+ 			id, strerror(errno), errno);
+ 		return;
+ 	}
+ 
+-	printf("Control 0x%08x set to %" PRId64 ", is %" PRId64 "\n",
++	fprintf(stderr, "Control 0x%08x set to %" PRId64 ", is %" PRId64 "\n",
+ 	       id, old_val, val);
+ }
+ 
+@@ -504,7 +504,7 @@ static int video_get_format(struct device *dev)
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_G_FMT, &fmt);
+ 	if (ret < 0) {
+-		printf("Unable to get format: %s (%d).\n", strerror(errno),
++		fprintf(stderr, "Unable to get format: %s (%d).\n", strerror(errno),
+ 			errno);
+ 		return ret;
+ 	}
+@@ -514,7 +514,7 @@ static int video_get_format(struct device *dev)
+ 		dev->height = fmt.fmt.pix_mp.height;
+ 		dev->num_planes = fmt.fmt.pix_mp.num_planes;
+ 
+-		printf("Video format: %s (%08x) %ux%u field %s, %u planes: \n",
++	    fprintf(stderr, "Video format: %s (%08x) %ux%u field %s, %u planes: \n",
+ 			v4l2_format_name(fmt.fmt.pix_mp.pixelformat), fmt.fmt.pix_mp.pixelformat,
+ 			fmt.fmt.pix_mp.width, fmt.fmt.pix_mp.height,
+ 			v4l2_field_name(fmt.fmt.pix_mp.field),
+@@ -527,7 +527,7 @@ static int video_get_format(struct device *dev)
+ 					fmt.fmt.pix_mp.plane_fmt[i].bytesperline ?
+ 						fmt.fmt.pix_mp.plane_fmt[i].sizeimage : 0;
+ 
+-			printf(" * Stride %u, buffer size %u\n",
++			fprintf(stderr, " * Stride %u, buffer size %u\n",
+ 				fmt.fmt.pix_mp.plane_fmt[i].bytesperline,
+ 				fmt.fmt.pix_mp.plane_fmt[i].sizeimage);
+ 		}
+@@ -539,7 +539,7 @@ static int video_get_format(struct device *dev)
+ 		dev->plane_fmt[0].bytesperline = fmt.fmt.pix.bytesperline;
+ 		dev->plane_fmt[0].sizeimage = fmt.fmt.pix.bytesperline ? fmt.fmt.pix.sizeimage : 0;
+ 
+-		printf("Video format: %s (%08x) %ux%u (stride %u) field %s buffer size %u\n",
++		fprintf(stderr, "Video format: %s (%08x) %ux%u (stride %u) field %s buffer size %u\n",
+ 			v4l2_format_name(fmt.fmt.pix.pixelformat), fmt.fmt.pix.pixelformat,
+ 			fmt.fmt.pix.width, fmt.fmt.pix.height, fmt.fmt.pix.bytesperline,
+ 			v4l2_field_name(fmt.fmt.pix_mp.field),
+@@ -581,25 +581,25 @@ static int video_set_format(struct device *dev, unsigned int w, unsigned int h,
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_S_FMT, &fmt);
+ 	if (ret < 0) {
+-		printf("Unable to set format: %s (%d).\n", strerror(errno),
++		fprintf(stderr, "Unable to set format: %s (%d).\n", strerror(errno),
+ 			errno);
+ 		return ret;
+ 	}
+ 
+ 	if (video_is_mplane(dev)) {
+-		printf("Video format set: %s (%08x) %ux%u field %s, %u planes: \n",
++		fprintf(stderr, "Video format set: %s (%08x) %ux%u field %s, %u planes: \n",
+ 			v4l2_format_name(fmt.fmt.pix_mp.pixelformat), fmt.fmt.pix_mp.pixelformat,
+ 			fmt.fmt.pix_mp.width, fmt.fmt.pix_mp.height,
+ 			v4l2_field_name(fmt.fmt.pix_mp.field),
+ 			fmt.fmt.pix_mp.num_planes);
+ 
+ 		for (i = 0; i < fmt.fmt.pix_mp.num_planes; i++) {
+-			printf(" * Stride %u, buffer size %u\n",
++			fprintf(stderr, " * Stride %u, buffer size %u\n",
+ 				fmt.fmt.pix_mp.plane_fmt[i].bytesperline,
+ 				fmt.fmt.pix_mp.plane_fmt[i].sizeimage);
+ 		}
+ 	} else {
+-		printf("Video format set: %s (%08x) %ux%u (stride %u) field %s buffer size %u\n",
++		fprintf(stderr, "Video format set: %s (%08x) %ux%u (stride %u) field %s buffer size %u\n",
+ 			v4l2_format_name(fmt.fmt.pix.pixelformat), fmt.fmt.pix.pixelformat,
+ 			fmt.fmt.pix.width, fmt.fmt.pix.height, fmt.fmt.pix.bytesperline,
+ 			v4l2_field_name(fmt.fmt.pix.field),
+@@ -619,16 +619,16 @@ static int video_set_framerate(struct device *dev, struct v4l2_fract *time_per_f
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_G_PARM, &parm);
+ 	if (ret < 0) {
+-		printf("Unable to get frame rate: %s (%d).\n",
++		fprintf(stderr, "Unable to get frame rate: %s (%d).\n",
+ 			strerror(errno), errno);
+ 		return ret;
+ 	}
+ 
+-	printf("Current frame rate: %u/%u\n",
++	fprintf(stderr, "Current frame rate: %u/%u\n",
+ 		parm.parm.capture.timeperframe.numerator,
+ 		parm.parm.capture.timeperframe.denominator);
+ 
+-	printf("Setting frame rate to: %u/%u\n",
++	fprintf(stderr, "Setting frame rate to: %u/%u\n",
+ 		time_per_frame->numerator,
+ 		time_per_frame->denominator);
+ 
+@@ -637,19 +637,19 @@ static int video_set_framerate(struct device *dev, struct v4l2_fract *time_per_f
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_S_PARM, &parm);
+ 	if (ret < 0) {
+-		printf("Unable to set frame rate: %s (%d).\n", strerror(errno),
++		fprintf(stderr, "Unable to set frame rate: %s (%d).\n", strerror(errno),
+ 			errno);
+ 		return ret;
+ 	}
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_G_PARM, &parm);
+ 	if (ret < 0) {
+-		printf("Unable to get frame rate: %s (%d).\n", strerror(errno),
++		fprintf(stderr, "Unable to get frame rate: %s (%d).\n", strerror(errno),
+ 			errno);
+ 		return ret;
+ 	}
+ 
+-	printf("Frame rate set: %u/%u\n",
++	fprintf(stderr, "Frame rate set: %u/%u\n",
+ 		parm.parm.capture.timeperframe.numerator,
+ 		parm.parm.capture.timeperframe.denominator);
+ 	return 0;
+@@ -674,7 +674,7 @@ static int video_buffer_mmap(struct device *dev, struct buffer *buffer,
+ 		buffer->mem[i] = mmap(0, length, PROT_READ | PROT_WRITE, MAP_SHARED,
+ 				      dev->fd, offset);
+ 		if (buffer->mem[i] == MAP_FAILED) {
+-			printf("Unable to map buffer %u/%u: %s (%d)\n",
++			fprintf(stderr, "Unable to map buffer %u/%u: %s (%d)\n",
+ 			       buffer->idx, i, strerror(errno), errno);
+ 			return -1;
+ 		}
+@@ -682,7 +682,7 @@ static int video_buffer_mmap(struct device *dev, struct buffer *buffer,
+ 		buffer->size[i] = length;
+ 		buffer->padding[i] = 0;
+ 
+-		printf("Buffer %u/%u mapped at address %p.\n",
++		fprintf(stderr, "Buffer %u/%u mapped at address %p.\n",
+ 		       buffer->idx, i, buffer->mem[i]);
+ 	}
+ 
+@@ -697,7 +697,7 @@ static int video_buffer_munmap(struct device *dev, struct buffer *buffer)
+ 	for (i = 0; i < dev->num_planes; i++) {
+ 		ret = munmap(buffer->mem[i], buffer->size[i]);
+ 		if (ret < 0) {
+-			printf("Unable to unmap buffer %u/%u: %s (%d)\n",
++			fprintf(stderr, "Unable to unmap buffer %u/%u: %s (%d)\n",
+ 			       buffer->idx, i, strerror(errno), errno);
+ 		}
+ 
+@@ -725,7 +725,7 @@ static int video_buffer_alloc_userptr(struct device *dev, struct buffer *buffer,
+ 		ret = posix_memalign(&buffer->mem[i], page_size,
+ 				     length + offset + padding);
+ 		if (ret < 0) {
+-			printf("Unable to allocate buffer %u/%u (%d)\n",
++			fprintf(stderr, "Unable to allocate buffer %u/%u (%d)\n",
+ 			       buffer->idx, i, ret);
+ 			return -ENOMEM;
+ 		}
+@@ -734,7 +734,7 @@ static int video_buffer_alloc_userptr(struct device *dev, struct buffer *buffer,
+ 		buffer->size[i] = length;
+ 		buffer->padding[i] = padding;
+ 
+-		printf("Buffer %u/%u allocated at address %p.\n",
++		fprintf(stderr, "Buffer %u/%u allocated at address %p.\n",
+ 		       buffer->idx, i, buffer->mem[i]);
+ 	}
+ 
+@@ -809,12 +809,12 @@ static int video_alloc_buffers(struct device *dev, int nbufs,
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_REQBUFS, &rb);
+ 	if (ret < 0) {
+-		printf("Unable to request buffers: %s (%d).\n", strerror(errno),
++		fprintf(stderr, "Unable to request buffers: %s (%d).\n", strerror(errno),
+ 			errno);
+ 		return ret;
+ 	}
+ 
+-	printf("%u buffers requested.\n", rb.count);
++	fprintf(stderr, "%u buffers requested.\n", rb.count);
+ 
+ 	buffers = malloc(rb.count * sizeof buffers[0]);
+ 	if (buffers == NULL)
+@@ -835,12 +835,12 @@ static int video_alloc_buffers(struct device *dev, int nbufs,
+ 
+ 		ret = ioctl(dev->fd, VIDIOC_QUERYBUF, &buf);
+ 		if (ret < 0) {
+-			printf("Unable to query buffer %u: %s (%d).\n", i,
++			fprintf(stderr, "Unable to query buffer %u: %s (%d).\n", i,
+ 				strerror(errno), errno);
+ 			return ret;
+ 		}
+ 		get_ts_flags(buf.flags, &ts_type, &ts_source);
+-		printf("length: %u offset: %u timestamp type/source: %s/%s\n",
++		fprintf(stderr, "length: %u offset: %u timestamp type/source: %s/%s\n",
+ 		       buf.length, buf.m.offset, ts_type, ts_source);
+ 
+ 		buffers[i].idx = i;
+@@ -899,12 +899,12 @@ static int video_free_buffers(struct device *dev)
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_REQBUFS, &rb);
+ 	if (ret < 0) {
+-		printf("Unable to release buffers: %s (%d).\n",
++		fprintf(stderr, "Unable to release buffers: %s (%d).\n",
+ 			strerror(errno), errno);
+ 		return ret;
+ 	}
+ 
+-	printf("%u buffers released.\n", dev->nbufs);
++	fprintf(stderr, "%u buffers released.\n", dev->nbufs);
+ 
+ 	free(dev->buffers);
+ 	dev->nbufs = 0;
+@@ -974,7 +974,7 @@ static int video_queue_buffer(struct device *dev, int index, enum buffer_fill_mo
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_QBUF, &buf);
+ 	if (ret < 0)
+-		printf("Unable to queue buffer: %s (%d).\n",
++		fprintf(stderr, "Unable to queue buffer: %s (%d).\n",
+ 			strerror(errno), errno);
+ 
+ 	return ret;
+@@ -987,7 +987,7 @@ static int video_enable(struct device *dev, int enable)
+ 
+ 	ret = ioctl(dev->fd, enable ? VIDIOC_STREAMON : VIDIOC_STREAMOFF, &type);
+ 	if (ret < 0) {
+-		printf("Unable to %s streaming: %s (%d).\n",
++		fprintf(stderr, "Unable to %s streaming: %s (%d).\n",
+ 			enable ? "start" : "stop", strerror(errno), errno);
+ 		return ret;
+ 	}
+@@ -1009,10 +1009,10 @@ static void video_query_menu(struct device *dev, struct v4l2_queryctrl *query,
+ 			continue;
+ 
+ 		if (query->type == V4L2_CTRL_TYPE_MENU)
+-			printf("  %u: %.32s%s\n", menu.index, menu.name,
++			fprintf(stderr, "  %u: %.32s%s\n", menu.index, menu.name,
+ 			       menu.index == value ? " (*)" : "");
+ 		else
+-			printf("  %u: %lld%s\n", menu.index, menu.value,
++			fprintf(stderr, "  %u: %lld%s\n", menu.index, menu.value,
+ 			       menu.index == value ? " (*)" : "");
+ 	};
+ }
+@@ -1043,7 +1043,7 @@ static void video_list_controls(struct device *dev)
+ 			continue;
+ 
+ 		if (query.type == V4L2_CTRL_TYPE_CTRL_CLASS) {
+-			printf("--- %s (class 0x%08x) ---\n", query.name, query.id);
++			fprintf(stderr, "--- %s (class 0x%08x) ---\n", query.name, query.id);
+ 			continue;
+ 		}
+ 
+@@ -1053,7 +1053,7 @@ static void video_list_controls(struct device *dev)
+ 		else
+ 			sprintf(value, "%" PRId64, val64);
+ 
+-		printf("control 0x%08x `%s' min %d max %d step %d default %d current %s.\n",
++		fprintf(stderr, "control 0x%08x `%s' min %d max %d step %d default %d current %s.\n",
+ 			query.id, query.name, query.minimum, query.maximum,
+ 			query.step, query.default_value, value);
+ 
+@@ -1065,9 +1065,9 @@ static void video_list_controls(struct device *dev)
+ 	}
+ 
+ 	if (nctrls)
+-		printf("%u control%s found.\n", nctrls, nctrls > 1 ? "s" : "");
++		fprintf(stderr, "%u control%s found.\n", nctrls, nctrls > 1 ? "s" : "");
+ 	else
+-		printf("No control found.\n");
++		fprintf(stderr, "No control found.\n");
+ }
+ 
+ static void video_enum_frame_intervals(struct device *dev, __u32 pixelformat,
+@@ -1088,30 +1088,30 @@ static void video_enum_frame_intervals(struct device *dev, __u32 pixelformat,
+ 			break;
+ 
+ 		if (i != ival.index)
+-			printf("Warning: driver returned wrong ival index "
++			fprintf(stderr, "Warning: driver returned wrong ival index "
+ 				"%u.\n", ival.index);
+ 		if (pixelformat != ival.pixel_format)
+-			printf("Warning: driver returned wrong ival pixel "
++			fprintf(stderr, "Warning: driver returned wrong ival pixel "
+ 				"format %08x.\n", ival.pixel_format);
+ 		if (width != ival.width)
+-			printf("Warning: driver returned wrong ival width "
++			fprintf(stderr, "Warning: driver returned wrong ival width "
+ 				"%u.\n", ival.width);
+ 		if (height != ival.height)
+-			printf("Warning: driver returned wrong ival height "
++			fprintf(stderr, "Warning: driver returned wrong ival height "
+ 				"%u.\n", ival.height);
+ 
+ 		if (i != 0)
+-			printf(", ");
++			fprintf(stderr, ", ");
+ 
+ 		switch (ival.type) {
+ 		case V4L2_FRMIVAL_TYPE_DISCRETE:
+-			printf("%u/%u",
++			fprintf(stderr, "%u/%u",
+ 				ival.discrete.numerator,
+ 				ival.discrete.denominator);
+ 			break;
+ 
+ 		case V4L2_FRMIVAL_TYPE_CONTINUOUS:
+-			printf("%u/%u - %u/%u",
++			fprintf(stderr, "%u/%u - %u/%u",
+ 				ival.stepwise.min.numerator,
+ 				ival.stepwise.min.denominator,
+ 				ival.stepwise.max.numerator,
+@@ -1119,7 +1119,7 @@ static void video_enum_frame_intervals(struct device *dev, __u32 pixelformat,
+ 			return;
+ 
+ 		case V4L2_FRMIVAL_TYPE_STEPWISE:
+-			printf("%u/%u - %u/%u (by %u/%u)",
++			fprintf(stderr, "%u/%u - %u/%u (by %u/%u)",
+ 				ival.stepwise.min.numerator,
+ 				ival.stepwise.min.denominator,
+ 				ival.stepwise.max.numerator,
+@@ -1149,23 +1149,23 @@ static void video_enum_frame_sizes(struct device *dev, __u32 pixelformat)
+ 			break;
+ 
+ 		if (i != frame.index)
+-			printf("Warning: driver returned wrong frame index "
++			fprintf(stderr, "Warning: driver returned wrong frame index "
+ 				"%u.\n", frame.index);
+ 		if (pixelformat != frame.pixel_format)
+-			printf("Warning: driver returned wrong frame pixel "
++			fprintf(stderr, "Warning: driver returned wrong frame pixel "
+ 				"format %08x.\n", frame.pixel_format);
+ 
+ 		switch (frame.type) {
+ 		case V4L2_FRMSIZE_TYPE_DISCRETE:
+-			printf("\tFrame size: %ux%u (", frame.discrete.width,
++			fprintf(stderr, "\tFrame size: %ux%u (", frame.discrete.width,
+ 				frame.discrete.height);
+ 			video_enum_frame_intervals(dev, frame.pixel_format,
+ 				frame.discrete.width, frame.discrete.height);
+-			printf(")\n");
++			fprintf(stderr, ")\n");
+ 			break;
+ 
+ 		case V4L2_FRMSIZE_TYPE_CONTINUOUS:
+-			printf("\tFrame size: %ux%u - %ux%u (",
++			fprintf(stderr, "\tFrame size: %ux%u - %ux%u (",
+ 				frame.stepwise.min_width,
+ 				frame.stepwise.min_height,
+ 				frame.stepwise.max_width,
+@@ -1173,11 +1173,11 @@ static void video_enum_frame_sizes(struct device *dev, __u32 pixelformat)
+ 			video_enum_frame_intervals(dev, frame.pixel_format,
+ 				frame.stepwise.max_width,
+ 				frame.stepwise.max_height);
+-			printf(")\n");
++			fprintf(stderr, ")\n");
+ 			break;
+ 
+ 		case V4L2_FRMSIZE_TYPE_STEPWISE:
+-			printf("\tFrame size: %ux%u - %ux%u (by %ux%u) (\n",
++			fprintf(stderr, "\tFrame size: %ux%u - %ux%u (by %ux%u) (\n",
+ 				frame.stepwise.min_width,
+ 				frame.stepwise.min_height,
+ 				frame.stepwise.max_width,
+@@ -1187,7 +1187,7 @@ static void video_enum_frame_sizes(struct device *dev, __u32 pixelformat)
+ 			video_enum_frame_intervals(dev, frame.pixel_format,
+ 				frame.stepwise.max_width,
+ 				frame.stepwise.max_height);
+-			printf(")\n");
++			fprintf(stderr, ")\n");
+ 			break;
+ 
+ 		default:
+@@ -1211,19 +1211,19 @@ static void video_enum_formats(struct device *dev, enum v4l2_buf_type type)
+ 			break;
+ 
+ 		if (i != fmt.index)
+-			printf("Warning: driver returned wrong format index "
++			fprintf(stderr, "Warning: driver returned wrong format index "
+ 				"%u.\n", fmt.index);
+ 		if (type != fmt.type)
+-			printf("Warning: driver returned wrong format type "
++			fprintf(stderr, "Warning: driver returned wrong format type "
+ 				"%u.\n", fmt.type);
+ 
+-		printf("\tFormat %u: %s (%08x)\n", i,
++		fprintf(stderr, "\tFormat %u: %s (%08x)\n", i,
+ 			v4l2_format_name(fmt.pixelformat), fmt.pixelformat);
+-		printf("\tType: %s (%u)\n", v4l2_buf_type_name(fmt.type),
++		fprintf(stderr, "\tType: %s (%u)\n", v4l2_buf_type_name(fmt.type),
+ 			fmt.type);
+-		printf("\tName: %.32s\n", fmt.description);
++		fprintf(stderr, "\tName: %.32s\n", fmt.description);
+ 		video_enum_frame_sizes(dev, fmt.pixelformat);
+-		printf("\n");
++		fprintf(stderr, "\n");
+ 	}
+ }
+ 
+@@ -1241,13 +1241,13 @@ static void video_enum_inputs(struct device *dev)
+ 			break;
+ 
+ 		if (i != input.index)
+-			printf("Warning: driver returned wrong input index "
++			fprintf(stderr, "Warning: driver returned wrong input index "
+ 				"%u.\n", input.index);
+ 
+-		printf("\tInput %u: %s.\n", i, input.name);
++		fprintf(stderr, "\tInput %u: %s.\n", i, input.name);
+ 	}
+ 
+-	printf("\n");
++	fprintf(stderr, "\n");
+ }
+ 
+ static int video_get_input(struct device *dev)
+@@ -1257,7 +1257,7 @@ static int video_get_input(struct device *dev)
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_G_INPUT, &input);
+ 	if (ret < 0) {
+-		printf("Unable to get current input: %s (%d).\n",
++		fprintf(stderr, "Unable to get current input: %s (%d).\n",
+ 			strerror(errno), errno);
+ 		return ret;
+ 	}
+@@ -1272,7 +1272,7 @@ static int video_set_input(struct device *dev, unsigned int input)
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_S_INPUT, &_input);
+ 	if (ret < 0)
+-		printf("Unable to select input %u: %s (%d).\n", input,
++		fprintf(stderr, "Unable to select input %u: %s (%d).\n", input,
+ 			strerror(errno), errno);
+ 
+ 	return ret;
+@@ -1291,14 +1291,14 @@ static int video_set_quality(struct device *dev, unsigned int quality)
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_S_JPEGCOMP, &jpeg);
+ 	if (ret < 0) {
+-		printf("Unable to set quality to %u: %s (%d).\n", quality,
++		fprintf(stderr, "Unable to set quality to %u: %s (%d).\n", quality,
+ 			strerror(errno), errno);
+ 		return ret;
+ 	}
+ 
+ 	ret = ioctl(dev->fd, VIDIOC_G_JPEGCOMP, &jpeg);
+ 	if (ret >= 0)
+-		printf("Quality set to %u\n", jpeg.quality);
++		fprintf(stderr, "Quality set to %u\n", jpeg.quality);
+ 
+ 	return 0;
+ }
+@@ -1313,7 +1313,7 @@ static int video_load_test_pattern(struct device *dev, const char *filename)
+ 	if (filename != NULL) {
+ 		fd = open(filename, O_RDONLY);
+ 		if (fd == -1) {
+-			printf("Unable to open test pattern file '%s': %s (%d).\n",
++			fprintf(stderr, "Unable to open test pattern file '%s': %s (%d).\n",
+ 				filename, strerror(errno), errno);
+ 			return -errno;
+ 		}
+@@ -1331,7 +1331,7 @@ static int video_load_test_pattern(struct device *dev, const char *filename)
+ 		if (filename != NULL) {
+ 			ret = read(fd, dev->pattern[plane], size);
+ 			if (ret != (int)size && dev->plane_fmt[plane].bytesperline != 0) {
+-				printf("Test pattern file size %u doesn't match image size %u\n",
++				fprintf(stderr, "Test pattern file size %u doesn't match image size %u\n",
+ 					ret, size);
+ 				ret = -EINVAL;
+ 				goto done;
+@@ -1341,7 +1341,7 @@ static int video_load_test_pattern(struct device *dev, const char *filename)
+ 			unsigned int i;
+ 
+ 			if (dev->plane_fmt[plane].bytesperline == 0) {
+-				printf("Compressed format detected for plane %u and no test pattern filename given.\n"
++				fprintf(stderr, "Compressed format detected for plane %u and no test pattern filename given.\n"
+ 					"The test pattern can't be generated automatically.\n", plane);
+ 				ret = -EINVAL;
+ 				goto done;
+@@ -1410,7 +1410,7 @@ static void video_verify_buffer(struct device *dev, struct v4l2_buffer *buf)
+ 
+ 		if (dev->plane_fmt[plane].sizeimage &&
+ 		    dev->plane_fmt[plane].sizeimage != length)
+-			printf("Warning: bytes used %u != image size %u for plane %u\n",
++			fprintf(stderr, "Warning: bytes used %u != image size %u for plane %u\n",
+ 			       length, dev->plane_fmt[plane].sizeimage, plane);
+ 
+ 		if (buffer->padding[plane] == 0)
+@@ -1424,16 +1424,16 @@ static void video_verify_buffer(struct device *dev, struct v4l2_buffer *buf)
+ 		}
+ 
+ 		if (errors) {
+-			printf("Warning: %u bytes overwritten among %u first padding bytes for plane %u\n",
++			fprintf(stderr, "Warning: %u bytes overwritten among %u first padding bytes for plane %u\n",
+ 			       errors, dirty, plane);
+ 
+ 			dirty = (dirty + 15) & ~15;
+ 			dirty = dirty > 32 ? 32 : dirty;
+ 
+ 			for (i = 0; i < dirty; ++i) {
+-				printf("%02x ", data[i]);
++				fprintf(stderr, "%02x ", data[i]);
+ 				if (i % 16 == 15)
+-					printf("\n");
++					fprintf(stderr, "\n");
+ 			}
+ 		}
+ 	}
+@@ -1481,18 +1481,32 @@ static void video_save_image(struct device *dev, struct v4l2_buffer *buf,
+ 
+ 		ret = write(fd, dev->buffers[buf->index].mem[i], length);
+ 		if (ret < 0) {
+-			printf("write error: %s (%d)\n", strerror(errno), errno);
++			fprintf(stderr, "write error: %s (%d)\n", strerror(errno), errno);
+ 			break;
+ 		} else if (ret != (int)length)
+-			printf("write error: only %d bytes written instead of %u\n",
++			fprintf(stderr, "write error: only %d bytes written instead of %u\n",
+ 			       ret, length);
+ 	}
+ 	close(fd);
+ }
+ 
++static void video_stdout_image(struct device *dev, struct v4l2_buffer *buf)
++{
++    int ret;
++
++    fprintf(stderr, "stdout");
++    ret = fwrite(dev->buffers[buf->index].mem, buf->bytesused, 1, stdout);
++
++    if (ret < 0)
++        fprintf(stderr, "write error: %s (%d)\n", strerror(errno), errno);
++    else if (ret != (int)buf->bytesused)
++        fprintf(stderr, "write error: only %d bytes written instead of %u\n",
++                ret, buf->bytesused);
++}
++
+ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 	unsigned int skip, unsigned int delay, const char *pattern,
+-	int do_requeue_last, enum buffer_fill_mode fill)
++	int do_requeue_last, enum buffer_fill_mode fill, int do_stdout)
+ {
+ 	struct v4l2_plane planes[VIDEO_MAX_PLANES];
+ 	struct v4l2_buffer buf;
+@@ -1529,7 +1543,7 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 		ret = ioctl(dev->fd, VIDIOC_DQBUF, &buf);
+ 		if (ret < 0) {
+ 			if (errno != EIO) {
+-				printf("Unable to dequeue buffer: %s (%d).\n",
++				fprintf(stderr, "Unable to dequeue buffer: %s (%d).\n",
+ 					strerror(errno), errno);
+ 				goto done;
+ 			}
+@@ -1550,7 +1564,7 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 
+ 		clock_gettime(CLOCK_MONOTONIC, &ts);
+ 		get_ts_flags(buf.flags, &ts_type, &ts_source);
+-		printf("%u (%u) [%c] %s %u %u B %ld.%06ld %ld.%06ld %.3f fps ts %s/%s\n", i, buf.index,
++		fprintf(stderr, "%u (%u) [%c] %s %u %u B %ld.%06ld %ld.%06ld %.3f fps ts %s/%s\n", i, buf.index,
+ 			(buf.flags & V4L2_BUF_FLAG_ERROR) ? 'E' : '-',
+ 			v4l2_field_name(buf.field),
+ 			buf.sequence, buf.bytesused, buf.timestamp.tv_sec,
+@@ -1563,6 +1577,9 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 		if (video_is_capture(dev) && pattern && !skip)
+ 			video_save_image(dev, &buf, pattern, i);
+ 
++		if (video_is_capture(dev) && do_stdout && !skip)
++			video_stdout_image(dev, &buf);
++
+ 		if (skip)
+ 			--skip;
+ 
+@@ -1577,7 +1594,7 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 
+ 		ret = video_queue_buffer(dev, buf.index, fill);
+ 		if (ret < 0) {
+-			printf("Unable to requeue buffer: %s (%d).\n",
++			fprintf(stderr, "Unable to requeue buffer: %s (%d).\n",
+ 				strerror(errno), errno);
+ 			goto done;
+ 		}
+@@ -1587,7 +1604,7 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 	video_enable(dev, 0);
+ 
+ 	if (nframes == 0) {
+-		printf("No frames captured.\n");
++		fprintf(stderr, "No frames captured.\n");
+ 		goto done;
+ 	}
+ 
+@@ -1604,7 +1621,7 @@ static int video_do_capture(struct device *dev, unsigned int nframes,
+ 	bps = size/(ts.tv_nsec/1000.0+1000000.0*ts.tv_sec)*1000000.0;
+ 	fps = i/(ts.tv_nsec/1000.0+1000000.0*ts.tv_sec)*1000000.0;
+ 
+-	printf("Captured %u frames in %lu.%06lu seconds (%f fps, %f B/s).\n",
++	fprintf(stderr, "Captured %u frames in %lu.%06lu seconds (%f fps, %f B/s).\n",
+ 		i, ts.tv_sec, ts.tv_nsec/1000, fps, bps);
+ 
+ done:
+@@ -1616,42 +1633,42 @@ done:
+ 
+ static void usage(const char *argv0)
+ {
+-	printf("Usage: %s [options] device\n", argv0);
+-	printf("Supported options:\n");
+-	printf("-B, --buffer-type		Buffer type (\"capture\", \"output\",\n");
+-	printf("                                \"capture-mplane\" or \"output-mplane\")\n");
+-	printf("-c, --capture[=nframes]		Capture frames\n");
+-	printf("-C, --check-overrun		Verify dequeued frames for buffer overrun\n");
+-	printf("-d, --delay			Delay (in ms) before requeuing buffers\n");
+-	printf("-f, --format format		Set the video format\n");
+-	printf("-F, --file[=name]		Read/write frames from/to disk\n");
+-	printf("\tFor video capture devices, the first '#' character in the file name is\n");
+-	printf("\texpanded to the frame sequence number. The default file name is\n");
+-	printf("\t'frame-#.bin'.\n");
+-	printf("-h, --help			Show this help screen\n");
+-	printf("-i, --input input		Select the video input\n");
+-	printf("-I, --fill-frames		Fill frames with check pattern before queuing them\n");
+-	printf("-l, --list-controls		List available controls\n");
+-	printf("-n, --nbufs n			Set the number of video buffers\n");
+-	printf("-p, --pause			Pause before starting the video stream\n");
+-	printf("-q, --quality n			MJPEG quality (0-100)\n");
+-	printf("-r, --get-control ctrl		Get control 'ctrl'\n");
+-	printf("-R, --realtime=[priority]	Enable realtime RR scheduling\n");
+-	printf("-s, --size WxH			Set the frame size\n");
+-	printf("-t, --time-per-frame num/denom	Set the time per frame (eg. 1/25 = 25 fps)\n");
+-	printf("-u, --userptr			Use the user pointers streaming method\n");
+-	printf("-w, --set-control 'ctrl value'	Set control 'ctrl' to 'value'\n");
+-	printf("    --enum-formats		Enumerate formats\n");
+-	printf("    --enum-inputs		Enumerate inputs\n");
+-	printf("    --fd                        Use a numeric file descriptor insted of a device\n");
+-	printf("    --field			Interlaced format field order\n");
+-	printf("    --no-query			Don't query capabilities on open\n");
+-	printf("    --offset			User pointer buffer offset from page start\n");
+-	printf("    --requeue-last		Requeue the last buffers before streamoff\n");
+-	printf("    --timestamp-source		Set timestamp source on output buffers [eof, soe]\n");
+-	printf("    --skip n			Skip the first n frames\n");
+-	printf("    --sleep-forever		Sleep forever after configuring the device\n");
+-	printf("    --stride value		Line stride in bytes\n");
++	fprintf(stderr, "Usage: %s [options] device\n", argv0);
++	fprintf(stderr, "Supported options:\n");
++	fprintf(stderr, "-B, --buffer-type		Buffer type (\"capture\", \"output\",\n");
++	fprintf(stderr, "                                \"capture-mplane\" or \"output-mplane\")\n");
++	fprintf(stderr, "-c, --capture[=nframes]		Capture frames\n");
++	fprintf(stderr, "-C, --check-overrun		Verify dequeued frames for buffer overrun\n");
++	fprintf(stderr, "-d, --delay			Delay (in ms) before requeuing buffers\n");
++	fprintf(stderr, "-f, --format format		Set the video format\n");
++	fprintf(stderr, "-F, --file[=name]		Read/write frames from/to disk\n");
++	fprintf(stderr, "\tFor video capture devices, the first '#' character in the file name is\n");
++	fprintf(stderr, "\texpanded to the frame sequence number. The default file name is\n");
++	fprintf(stderr, "\t'frame-#.bin'.\n");
++	fprintf(stderr, "-h, --help			Show this help screen\n");
++	fprintf(stderr, "-i, --input input		Select the video input\n");
++	fprintf(stderr, "-I, --fill-frames		Fill frames with check pattern before queuing them\n");
++	fprintf(stderr, "-l, --list-controls		List available controls\n");
++	fprintf(stderr, "-n, --nbufs n			Set the number of video buffers\n");
++	fprintf(stderr, "-p, --pause			Pause before starting the video stream\n");
++	fprintf(stderr, "-q, --quality n			MJPEG quality (0-100)\n");
++	fprintf(stderr, "-r, --get-control ctrl		Get control 'ctrl'\n");
++	fprintf(stderr, "-R, --realtime=[priority]	Enable realtime RR scheduling\n");
++	fprintf(stderr, "-s, --size WxH			Set the frame size\n");
++	fprintf(stderr, "-t, --time-per-frame num/denom	Set the time per frame (eg. 1/25 = 25 fps)\n");
++	fprintf(stderr, "-u, --userptr			Use the user pointers streaming method\n");
++	fprintf(stderr, "-w, --set-control 'ctrl value'	Set control 'ctrl' to 'value'\n");
++	fprintf(stderr, "    --enum-formats		Enumerate formats\n");
++	fprintf(stderr, "    --enum-inputs		Enumerate inputs\n");
++	fprintf(stderr, "    --fd                        Use a numeric file descriptor insted of a device\n");
++	fprintf(stderr, "    --field			Interlaced format field order\n");
++	fprintf(stderr, "    --no-query			Don't query capabilities on open\n");
++	fprintf(stderr, "    --offset			User pointer buffer offset from page start\n");
++	fprintf(stderr, "    --requeue-last		Requeue the last buffers before streamoff\n");
++	fprintf(stderr, "    --timestamp-source		Set timestamp source on output buffers [eof, soe]\n");
++	fprintf(stderr, "    --skip n			Skip the first n frames\n");
++	fprintf(stderr, "    --sleep-forever		Sleep forever after configuring the device\n");
++	fprintf(stderr, "    --stride value		Line stride in bytes\n");
+ }
+ 
+ #define OPT_ENUM_FORMATS	256
+@@ -1665,6 +1682,7 @@ static void usage(const char *argv0)
+ #define OPT_FD			264
+ #define OPT_TSTAMP_SRC		265
+ #define OPT_FIELD		266
++#define OPT_STDOUT		267
+ 
+ static struct option opts[] = {
+ 	{"buffer-type", 1, 0, 'B'},
+@@ -1677,6 +1695,7 @@ static struct option opts[] = {
+ 	{"field", 1, 0, OPT_FIELD},
+ 	{"file", 2, 0, 'F'},
+ 	{"fill-frames", 0, 0, 'I'},
++	{"stdout", 0, 0, OPT_STDOUT},
+ 	{"format", 1, 0, 'f'},
+ 	{"help", 0, 0, 'h'},
+ 	{"input", 1, 0, 'i'},
+@@ -1717,7 +1736,8 @@ int main(int argc, char *argv[])
+ 	int do_list_controls = 0, do_get_control = 0, do_set_control = 0;
+ 	int do_sleep_forever = 0, do_requeue_last = 0;
+ 	int do_rt = 0;
+-	int no_query = 0;
++	int no_query = 0; 
++	int do_stdout = 0;
+ 	char *endptr;
+ 	int c;
+ 
+@@ -1755,7 +1775,7 @@ int main(int argc, char *argv[])
+ 		case 'B':
+ 			ret = v4l2_buf_type_from_string(optarg);
+ 			if (ret == -1) {
+-				printf("Bad buffer type \"%s\"\n", optarg);
++				fprintf(stderr, "Bad buffer type \"%s\"\n", optarg);
+ 				return 1;
+ 			}
+ 			video_set_buf_type(&dev, ret);
+@@ -1775,7 +1795,7 @@ int main(int argc, char *argv[])
+ 			do_set_format = 1;
+ 			info = v4l2_format_by_name(optarg);
+ 			if (info == NULL) {
+-				printf("Unsupported video format '%s'\n", optarg);
++				fprintf(stderr, "Unsupported video format '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			pixelformat = info->fourcc;
+@@ -1812,7 +1832,7 @@ int main(int argc, char *argv[])
+ 		case 'r':
+ 			ctrl_name = strtol(optarg, &endptr, 0);
+ 			if (*endptr != 0) {
+-				printf("Invalid control name '%s'\n", optarg);
++				fprintf(stderr, "Invalid control name '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			do_get_control = 1;
+@@ -1826,12 +1846,12 @@ int main(int argc, char *argv[])
+ 			do_set_format = 1;
+ 			width = strtol(optarg, &endptr, 10);
+ 			if (*endptr != 'x' || endptr == optarg) {
+-				printf("Invalid size '%s'\n", optarg);
++				fprintf(stderr, "Invalid size '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			height = strtol(endptr + 1, &endptr, 10);
+ 			if (*endptr != 0) {
+-				printf("Invalid size '%s'\n", optarg);
++				fprintf(stderr, "Invalid size '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			break;
+@@ -1839,12 +1859,12 @@ int main(int argc, char *argv[])
+ 			do_set_time_per_frame = 1;
+ 			time_per_frame.numerator = strtol(optarg, &endptr, 10);
+ 			if (*endptr != '/' || endptr == optarg) {
+-				printf("Invalid time per frame '%s'\n", optarg);
++				fprintf(stderr, "Invalid time per frame '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			time_per_frame.denominator = strtol(endptr + 1, &endptr, 10);
+ 			if (*endptr != 0) {
+-				printf("Invalid time per frame '%s'\n", optarg);
++				fprintf(stderr, "Invalid time per frame '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			break;
+@@ -1854,12 +1874,12 @@ int main(int argc, char *argv[])
+ 		case 'w':
+ 			ctrl_name = strtol(optarg, &endptr, 0);
+ 			if (*endptr != ' ' || endptr == optarg) {
+-				printf("Invalid control name '%s'\n", optarg);
++				fprintf(stderr, "Invalid control name '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			ctrl_value = strtol(endptr + 1, &endptr, 0);
+ 			if (*endptr != 0) {
+-				printf("Invalid control value '%s'\n", optarg);
++				fprintf(stderr, "Invalid control value '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			do_set_control = 1;
+@@ -1873,16 +1893,16 @@ int main(int argc, char *argv[])
+ 		case OPT_FD:
+ 			ret = atoi(optarg);
+ 			if (ret < 0) {
+-				printf("Bad file descriptor %d\n", ret);
++				fprintf(stderr, "Bad file descriptor %d\n", ret);
+ 				return 1;
+ 			}
+-			printf("Using file descriptor %d\n", ret);
++			fprintf(stderr, "Using file descriptor %d\n", ret);
+ 			video_set_fd(&dev, ret);
+ 			break;
+ 		case OPT_FIELD:
+ 			field = v4l2_field_from_string(optarg);
+ 			if (field == (enum v4l2_field)-1) {
+-				printf("Invalid field order '%s'\n", optarg);
++				fprintf(stderr, "Invalid field order '%s'\n", optarg);
+ 				return 1;
+ 			}
+ 			break;
+@@ -1907,22 +1927,25 @@ int main(int argc, char *argv[])
+ 			} else if (!strcmp(optarg, "soe")) {
+ 				dev.buffer_output_flags |= V4L2_BUF_FLAG_TSTAMP_SRC_SOE;
+ 			} else {
+-				printf("Invalid timestamp source %s\n", optarg);
++				fprintf(stderr, "Invalid timestamp source %s\n", optarg);
+ 				return 1;
+ 			}
+ 			break;
+ 		case OPT_USERPTR_OFFSET:
+ 			userptr_offset = atoi(optarg);
+ 			break;
++		case OPT_STDOUT:
++			do_stdout = 1;
++			break;
+ 		default:
+-			printf("Invalid option -%c\n", c);
+-			printf("Run %s -h for help.\n", argv[0]);
++			fprintf(stderr, "Invalid option -%c\n", c);
++			fprintf(stderr, "Run %s -h for help.\n", argv[0]);
+ 			return 1;
+ 		}
+ 	}
+ 
+ 	if ((fill_mode & BUFFER_FILL_PADDING) && memtype != V4L2_MEMORY_USERPTR) {
+-		printf("Buffer overrun can only be checked in USERPTR mode.\n");
++		fprintf(stderr, "Buffer overrun can only be checked in USERPTR mode.\n");
+ 		return 1;
+ 	}
+ 
+@@ -1959,7 +1982,7 @@ int main(int argc, char *argv[])
+ 		ret = get_control(&dev, ctrl_name,
+ 				  get_control_type(&dev, ctrl_name), &val);
+ 		if (ret >= 0)
+-			printf("Control 0x%08x value %" PRId64 "\n", ctrl_name, val);
++			fprintf(stderr, "Control 0x%08x value %" PRId64 "\n", ctrl_name, val);
+ 	}
+ 
+ 	if (do_set_control)
+@@ -1970,7 +1993,7 @@ int main(int argc, char *argv[])
+ 		video_list_controls(&dev);
+ 
+ 	if (do_enum_formats) {
+-		printf("- Available formats:\n");
++		fprintf(stderr, "- Available formats:\n");
+ 		video_enum_formats(&dev, V4L2_BUF_TYPE_VIDEO_CAPTURE);
+ 		video_enum_formats(&dev, V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE);
+ 		video_enum_formats(&dev, V4L2_BUF_TYPE_VIDEO_OUTPUT);
+@@ -1979,14 +2002,14 @@ int main(int argc, char *argv[])
+ 	}
+ 
+ 	if (do_enum_inputs) {
+-		printf("- Available inputs:\n");
++		fprintf(stderr, "- Available inputs:\n");
+ 		video_enum_inputs(&dev);
+ 	}
+ 
+ 	if (do_set_input) {
+ 		video_set_input(&dev, input);
+ 		ret = video_get_input(&dev);
+-		printf("Input %d selected\n", ret);
++		fprintf(stderr, "Input %d selected\n", ret);
+ 	}
+ 
+ 	/* Set the video format. */
+@@ -2028,7 +2051,7 @@ int main(int argc, char *argv[])
+ 	}
+ 
+ 	if (do_pause) {
+-		printf("Press enter to start capture\n");
++		fprintf(stderr, "Press enter to start capture\n");
+ 		getchar();
+ 	}
+ 
+@@ -2037,12 +2060,12 @@ int main(int argc, char *argv[])
+ 		sched.sched_priority = rt_priority;
+ 		ret = sched_setscheduler(0, SCHED_RR, &sched);
+ 		if (ret < 0)
+-			printf("Failed to select RR scheduler: %s (%d)\n",
++			fprintf(stderr, "Failed to select RR scheduler: %s (%d)\n",
+ 				strerror(errno), errno);
+ 	}
+ 
+ 	if (video_do_capture(&dev, nframes, skip, delay, filename,
+-			     do_requeue_last, fill_mode) < 0) {
++			     do_requeue_last, fill_mode, do_stdout) < 0) {
+ 		video_close(&dev);
+ 		return 1;
+ 	}
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/v4l2apps/yavta_git.bb
+++ b/recipes-multimedia/v4l2apps/yavta_git.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Yet Another V4L2 Test Application"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING.GPL;md5=751419260aa954499f7abaabaa882bbe"
+
+SRC_URI = "git://git.ideasonboard.org/yavta.git \
+           file://0001-Add-stdout-mode-to-allow-streaming-over-the-network-.patch"
+SRCREV = "7e9f28bedc1ed3205fb5164f686aea96f27a0de2"
+
+PV = "0.0"
+PR = "r2"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "-e MAKEFLAGS="
+
+# The yavta sources include copies of the headers required to build in the
+# include directory.  The Makefile uses CFLAGS to include these, but since
+# we override the CFLAGS then we need to add this include path back in.
+CFLAGS += "-I${S}/include"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 yavta ${D}${bindir}
+}
+
+


### PR DESCRIPTION
Import recipe from meta-openembedded's meta-oe, as of commit `a23d4e0458d954c93f1ce0ada3f6e79fbfae3934` ("v4l-utils: upgrade 1.18.0 -> 1.18.1").