### PR TITLE
perf: Add libcap dependency

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -3,3 +3,6 @@
 # ("libbpf: Move bpf_{helpers, helper_defs, endian, tracing}.h into
 # libbpf").
 PERF_SRC += "scripts"
+
+RDEPENDS_${PN} += "libcap"
+RDEPENDS_${PN}-python += "libcap"


### PR DESCRIPTION
Avoid this sort of QA error with newer versions of Perf:
```
ERROR: perf-1.0-r9 do_package_qa: QA Issue: /usr/bin/trace contained in package perf requires libcap.so.2()(64bit), but no providers found in RDEPENDS_perf? [file-rdeps]
ERROR: perf-1.0-r9 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: Logfile of failure stored in: /poky/build/tmp/work/juno-poky-linux/perf/1.0-r9/temp/log.do_package_qa.32217
ERROR: Task (/poky/meta/recipes-kernel/perf/perf.bb:do_package_qa) failed with exit code '1'
```