### PR TITLE
Add igt-gpu-tools

### DIFF
--- a/recipes-devtools/meson/meson.inc
+++ b/recipes-devtools/meson/meson.inc
@@ -1,0 +1,31 @@
+HOMEPAGE = "http://mesonbuild.com"
+SUMMARY = "A high performance build system"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "https://github.com/mesonbuild/meson/releases/download/${PV}/meson-${PV}.tar.gz \
+           file://0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch \
+           file://0002-gobject-introspection-determine-g-ir-scanner-and-g-i.patch \
+           file://0001-Linker-rules-move-cross_args-in-front-of-output_args.patch \
+           file://0003-native_bindir.patch \
+           file://gi-flags.patch \
+           file://gtkdoc-flags.patch \
+           file://0001-python-module-do-not-manipulate-the-environment-when.patch \
+           file://disable-rpath-handling.patch \
+           "
+SRC_URI[sha256sum] = "92d8afd921751261e36151643464efd3394162f69efbe8cd53e0a66b1cf395eb"
+SRC_URI[md5sum] = "31bda3519d8c0eb3438267268a78085e"
+
+SRC_URI_append_class-native = " \
+    file://0002-Make-CPU-family-warnings-fatal.patch \
+    file://0001-Support-building-allarch-recipes-again.patch \
+"
+
+UPSTREAM_CHECK_URI = "https://github.com/mesonbuild/meson/releases"
+
+inherit setuptools3
+
+RDEPENDS_${PN} = "ninja python3-core python3-modules"
+
+FILES_${PN} += "${datadir}/polkit-1"

--- a/recipes-devtools/meson/meson/0001-Linker-rules-move-cross_args-in-front-of-output_args.patch
+++ b/recipes-devtools/meson/meson/0001-Linker-rules-move-cross_args-in-front-of-output_args.patch
@@ -1,0 +1,30 @@
+From 4676224dbdff0f7107e8cbdbe0eab19c855f1454 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 17 Nov 2017 13:18:28 +0200
+Subject: [PATCH] Linker rules: move {cross_args} in front of {output_args}
+
+The previous order was found to break linking in some cases
+(e.g. when -no-pic -fno-PIC was present in {cross_args}.
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ mesonbuild/backend/ninjabackend.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mesonbuild/backend/ninjabackend.py b/mesonbuild/backend/ninjabackend.py
+index bb281e1..969b70e 100644
+--- a/mesonbuild/backend/ninjabackend.py
++++ b/mesonbuild/backend/ninjabackend.py
+@@ -1501,7 +1501,7 @@ int dummy;
+  rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
+ '''
+                 else:
+-                    command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
++                    command_template = ' command = {executable} $ARGS {cross_args} {output_args} $in $LINK_ARGS $aliasing\n'
+                 command = command_template.format(
+                     executable=' '.join(compiler.get_linker_exelist()),
+                     cross_args=' '.join(cross_args),
+-- 
+2.15.0
+

--- a/recipes-devtools/meson/meson/0001-Support-building-allarch-recipes-again.patch
+++ b/recipes-devtools/meson/meson/0001-Support-building-allarch-recipes-again.patch
@@ -1,0 +1,25 @@
+From d80d02a3ca6e21fa3d055c88c05234c2eb4db128 Mon Sep 17 00:00:00 2001
+From: Peter Kjellerstedt <pkj@axis.com>
+Date: Thu, 26 Jul 2018 16:32:49 +0200
+Subject: [PATCH] Support building allarch recipes again
+
+This registers "allarch" as a known CPU family.
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ mesonbuild/environment.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: meson-0.47.2/mesonbuild/environment.py
+===================================================================
+--- meson-0.47.2.orig/mesonbuild/environment.py
++++ meson-0.47.2/mesonbuild/environment.py
+@@ -75,6 +75,7 @@ from .compilers import (
+ build_filename = 'meson.build'
+ 
+ known_cpu_families = (
++    'allarch',
+     'aarch64',
+     'arm',
+     'e2k',

--- a/recipes-devtools/meson/meson/0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch
+++ b/recipes-devtools/meson/meson/0001-gtkdoc-fix-issues-that-arise-when-cross-compiling.patch
@@ -1,0 +1,85 @@
+From 3ac4e58c5494bd7e603a325b5b5c2b8075849fee Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 4 Aug 2017 16:16:41 +0300
+Subject: [PATCH] gtkdoc: fix issues that arise when cross-compiling
+
+Specifically:
+1) Make it possible to specify a wrapper for executing binaries
+(usually, some kind of target hardware emulator, such as qemu)
+2) Explicitly provide CC and LD via command line, as otherwise gtk-doc will
+try to guess them, incorrectly.
+3) If things break down, print the full command with arguments,
+not just the binary name.
+4) Correctly determine the compiler/linker executables and cross-options when cross-compiling
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/gnome.py        | 18 +++++++++++++++---
+ mesonbuild/scripts/gtkdochelper.py |  9 +++++++--
+ 2 files changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index cb69641..727eb6a 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -792,6 +792,10 @@ This will become a hard error in the future.''')
+                 '--mode=' + mode]
+         if namespace:
+             args.append('--namespace=' + namespace)
++        gtkdoc_exe_wrapper = state.environment.cross_info.config["properties"].get('gtkdoc_exe_wrapper', None)
++        if gtkdoc_exe_wrapper is not None:
++            args.append('--gtkdoc-exe-wrapper=' + gtkdoc_exe_wrapper)
++
+         args += self._unpack_args('--htmlargs=', 'html_args', kwargs)
+         args += self._unpack_args('--scanargs=', 'scan_args', kwargs)
+         args += self._unpack_args('--scanobjsargs=', 'scanobjs_args', kwargs)
+diff --git a/mesonbuild/scripts/gtkdochelper.py b/mesonbuild/scripts/gtkdochelper.py
+index 948dc5a..9c5bd19 100644
+--- a/mesonbuild/scripts/gtkdochelper.py
++++ b/mesonbuild/scripts/gtkdochelper.py
+@@ -45,6 +45,7 @@ parser.add_argument('--ignore-headers', dest='ignore_headers', default='')
+ parser.add_argument('--namespace', dest='namespace', default='')
+ parser.add_argument('--mode', dest='mode', default='')
+ parser.add_argument('--installdir', dest='install_dir')
++parser.add_argument('--gtkdoc-exe-wrapper', dest='gtkdoc_exe_wrapper')
+ 
+ def gtkdoc_run_check(cmd, cwd, library_paths=None):
+     if library_paths is None:
+@@ -64,7 +65,7 @@ def gtkdoc_run_check(cmd, cwd, library_paths=None):
+     # This preserves the order of messages.
+     p, out = Popen_safe(cmd, cwd=cwd, env=env, stderr=subprocess.STDOUT)[0:2]
+     if p.returncode != 0:
+-        err_msg = ["{!r} failed with status {:d}".format(cmd[0], p.returncode)]
++        err_msg = ["{!r} failed with status {:d}".format(cmd, p.returncode)]
+         if out:
+             err_msg.append(out)
+         raise MesonException('\n'.join(err_msg))
+@@ -74,7 +75,7 @@ def gtkdoc_run_check(cmd, cwd, library_paths=None):
+ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
+                  main_file, module,
+                  html_args, scan_args, fixxref_args, mkdb_args,
+-                 gobject_typesfile, scanobjs_args, ld, cc, ldflags, cflags,
++                 gobject_typesfile, scanobjs_args, gtkdoc_exe_wrapper, ld, cc, ldflags, cflags,
+                  html_assets, content_files, ignore_headers, namespace,
+                  expand_content_files, mode):
+     print("Building documentation for %s" % module)
+@@ -135,6 +136,9 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
+     if gobject_typesfile:
+         scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + ['--types=' + gobject_typesfile,
+                                                               '--module=' + module,
++                                                              '--run=' + gtkdoc_exe_wrapper,
++                                                              '--cc=' + cc,
++                                                              '--ld=' + ld,
+                                                               '--cflags=' + cflags,
+                                                               '--ldflags=' + ldflags,
+                                                               '--cc=' + cc,
+@@ -238,6 +242,7 @@ def run(args):
+         mkdbargs,
+         options.gobject_typesfile,
+         scanobjsargs,
++        options.gtkdoc_exe_wrapper,
+         options.ld,
+         options.cc,
+         options.ldflags,

--- a/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
+++ b/recipes-devtools/meson/meson/0001-python-module-do-not-manipulate-the-environment-when.patch
@@ -1,0 +1,43 @@
+From 45426f06689a520fc47f81ee29b49d509f11ba58 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 19 Nov 2018 14:24:26 +0100
+Subject: [PATCH] python module: do not manipulate the environment when calling
+ pkg-config
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ mesonbuild/modules/python.py | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+diff --git a/mesonbuild/modules/python.py b/mesonbuild/modules/python.py
+index 1195d8a..df81da4 100644
+--- a/mesonbuild/modules/python.py
++++ b/mesonbuild/modules/python.py
+@@ -67,26 +67,12 @@ class PythonDependency(ExternalDependency):
+         if DependencyMethods.PKGCONFIG in self.methods and not python_holder.is_pypy:
+             pkg_version = self.variables.get('LDVERSION') or self.version
+             pkg_libdir = self.variables.get('LIBPC')
+-            old_pkg_libdir = os.environ.get('PKG_CONFIG_LIBDIR')
+-            old_pkg_path = os.environ.get('PKG_CONFIG_PATH')
+-
+-            os.environ.pop('PKG_CONFIG_PATH', None)
+-
+-            if pkg_libdir:
+-                os.environ['PKG_CONFIG_LIBDIR'] = pkg_libdir
+ 
+             try:
+                 self.pkgdep = PkgConfigDependency('python-{}'.format(pkg_version), environment, kwargs)
+             except Exception:
+                 pass
+ 
+-            if old_pkg_path is not None:
+-                os.environ['PKG_CONFIG_PATH'] = old_pkg_path
+-
+-            if old_pkg_libdir is not None:
+-                os.environ['PKG_CONFIG_LIBDIR'] = old_pkg_libdir
+-            else:
+-                os.environ.pop('PKG_CONFIG_LIBDIR', None)
+ 
+         if self.pkgdep and self.pkgdep.found():
+             self.compile_args = self.pkgdep.get_compile_args()

--- a/recipes-devtools/meson/meson/0002-Make-CPU-family-warnings-fatal.patch
+++ b/recipes-devtools/meson/meson/0002-Make-CPU-family-warnings-fatal.patch
@@ -1,0 +1,36 @@
+From 2e8553fc01e62ebc4faa240bf20984a8a0ac7387 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Tue, 3 Jul 2018 13:59:09 +0100
+Subject: [PATCH] Make CPU family warnings fatal
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+---
+ mesonbuild/environment.py | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/mesonbuild/environment.py b/mesonbuild/environment.py
+index d29a77f..267acf9 100644
+--- a/mesonbuild/environment.py
++++ b/mesonbuild/environment.py
+@@ -239,9 +239,7 @@ def detect_cpu_family(compilers):
+         return 'x86_64'
+ 
+     if trial not in known_cpu_families:
+-        mlog.warning('Unknown CPU family {!r}, please report this at '
+-                     'https://github.com/mesonbuild/meson/issues/new with the'
+-                     'output of `uname -a` and `cat /proc/cpuinfo`'.format(trial))
++        raise EnvironmentException('Unknown CPU family %s, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.' % trial)
+ 
+     return trial
+ 
+@@ -1014,7 +1012,7 @@ class CrossBuildInfo:
+                     raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
+ 
+                 if entry == 'cpu_family' and res not in known_cpu_families:
+-                    mlog.warning('Unknown CPU family %s, please report this at https://github.com/mesonbuild/meson/issues/new' % value)
++                    raise EnvironmentException('Unknown CPU family %s, see https://wiki.yoctoproject.org/wiki/Meson/UnknownCPU for directions.' % value)
+ 
+                 if self.ok_type(res):
+                     self.config[s][entry] = res

--- a/recipes-devtools/meson/meson/0002-gobject-introspection-determine-g-ir-scanner-and-g-i.patch
+++ b/recipes-devtools/meson/meson/0002-gobject-introspection-determine-g-ir-scanner-and-g-i.patch
@@ -1,0 +1,39 @@
+From 0b860cb8a22ae876b6088939dbabca216bc29431 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 4 Aug 2017 16:18:47 +0300
+Subject: [PATCH] gobject-introspection: determine g-ir-scanner and
+ g-ir-compiler paths from pkgconfig
+
+Do not hardcode the name of those binaries; gobject-introspection
+provides them via pkgconfig, and they can be set to something else
+(for example when cross-compiling).
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ mesonbuild/modules/gnome.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index b29bab9..dc4c401 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -393,8 +393,6 @@ class GnomeModule(ExtensionModule):
+             raise MesonException('Gir takes one argument')
+         if kwargs.get('install_dir'):
+             raise MesonException('install_dir is not supported with generate_gir(), see "install_dir_gir" and "install_dir_typelib"')
+-        giscanner = self.interpreter.find_program_impl('g-ir-scanner')
+-        gicompiler = self.interpreter.find_program_impl('g-ir-compiler')
+         girtarget = args[0]
+         while hasattr(girtarget, 'held_object'):
+             girtarget = girtarget.held_object
+@@ -405,6 +403,8 @@ class GnomeModule(ExtensionModule):
+                 self.gir_dep = PkgConfigDependency('gobject-introspection-1.0',
+                                                    state.environment,
+                                                    {'native': True})
++            giscanner = os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_scanner', {})
++            gicompiler = os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_compiler', {})
+             pkgargs = self.gir_dep.get_compile_args()
+         except Exception:
+             raise MesonException('gobject-introspection dependency was not found, gir cannot be generated.')

--- a/recipes-devtools/meson/meson/0003-native_bindir.patch
+++ b/recipes-devtools/meson/meson/0003-native_bindir.patch
@@ -1,0 +1,125 @@
+From e762d85c823adfefc27ba6128c7b997aa50166ce Mon Sep 17 00:00:00 2001
+From: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+Date: Wed, 15 Nov 2017 15:05:01 +0100
+Subject: [PATCH] native_bindir
+
+Some libraries, like QT, have pre-processors that convert their input
+files into something that the cross-compiler can process. We find the
+path of those pre-processors via pkg-config-native instead of
+pkg-config.
+
+This path forces the use of pkg-config-native for host_bins arguments.
+
+There are some discussions upstream to merge this patch, but I presonaly believe
+that is is OE only. https://github.com/mesonbuild/meson/issues/1849#issuecomment-303730323
+
+Upstream-Status: Inappropriate [OE specific]
+Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>
+
+---
+ mesonbuild/dependencies/base.py | 19 +++++++++++--------
+ mesonbuild/dependencies/ui.py   |  6 +++---
+ 2 files changed, 14 insertions(+), 11 deletions(-)
+
+diff --git a/mesonbuild/dependencies/base.py b/mesonbuild/dependencies/base.py
+index 6d3678f..90fdb80 100644
+--- a/mesonbuild/dependencies/base.py
++++ b/mesonbuild/dependencies/base.py
+@@ -146,7 +146,7 @@ class Dependency:
+     def need_threads(self):
+         return False
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         raise DependencyException('{!r} is not a pkgconfig dependency'.format(self.name))
+ 
+     def get_configtool_variable(self, variable_name):
+@@ -183,7 +183,7 @@ class InternalDependency(Dependency):
+         self.sources = sources
+         self.ext_deps = ext_deps
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         raise DependencyException('Method "get_pkgconfig_variable()" is '
+                                   'invalid for an internal dependency')
+ 
+@@ -523,15 +523,18 @@ class PkgConfigDependency(ExternalDependency):
+         return s.format(self.__class__.__name__, self.name, self.is_found,
+                         self.version_reqs)
+ 
+-    def _call_pkgbin_real(self, args, env):
+-        cmd = self.pkgbin.get_command() + args
++    def _call_pkgbin_real(self, args, env, use_native=False):
++        if use_native:
++            cmd = self.pkgbin.get_command() + "-native" + args
++        else:
++            cmd = self.pkgbin.get_command() + args
+         p, out = Popen_safe(cmd, env=env)[0:2]
+         rc, out = p.returncode, out.strip()
+         call = ' '.join(cmd)
+         mlog.debug("Called `{}` -> {}\n{}".format(call, rc, out))
+         return rc, out
+ 
+-    def _call_pkgbin(self, args, env=None):
++    def _call_pkgbin(self, args, env=None, use_native=False):
+         if env is None:
+             fenv = env
+             env = os.environ
+@@ -540,7 +543,7 @@ class PkgConfigDependency(ExternalDependency):
+         targs = tuple(args)
+         cache = PkgConfigDependency.pkgbin_cache
+         if (self.pkgbin, targs, fenv) not in cache:
+-            cache[(self.pkgbin, targs, fenv)] = self._call_pkgbin_real(args, env)
++            cache[(self.pkgbin, targs, fenv)] = self._call_pkgbin_real(args, env, use_native)
+         return cache[(self.pkgbin, targs, fenv)]
+ 
+     def _convert_mingw_paths(self, args):
+@@ -718,7 +721,7 @@ class PkgConfigDependency(ExternalDependency):
+                                       (self.name, out_raw))
+         self.link_args, self.raw_link_args = self._search_libs(out, out_raw)
+ 
+-    def get_pkgconfig_variable(self, variable_name, kwargs):
++    def get_pkgconfig_variable(self, variable_name, kwargs, use_native=False):
+         options = ['--variable=' + variable_name, self.name]
+ 
+         if 'define_variable' in kwargs:
+@@ -731,7 +734,7 @@ class PkgConfigDependency(ExternalDependency):
+ 
+             options = ['--define-variable=' + '='.join(definition)] + options
+ 
+-        ret, out = self._call_pkgbin(options)
++        ret, out = self._call_pkgbin(options, use_native=use_native)
+         variable = ''
+         if ret != 0:
+             if self.required:
+diff --git a/mesonbuild/dependencies/ui.py b/mesonbuild/dependencies/ui.py
+index 197d22c..c683d21 100644
+--- a/mesonbuild/dependencies/ui.py
++++ b/mesonbuild/dependencies/ui.py
+@@ -285,7 +285,7 @@ class QtBaseDependency(ExternalDependency):
+         self.bindir = self.get_pkgconfig_host_bins(core)
+         if not self.bindir:
+             # If exec_prefix is not defined, the pkg-config file is broken
+-            prefix = core.get_pkgconfig_variable('exec_prefix', {})
++            prefix = core.get_pkgconfig_variable('exec_prefix', {}, use_native=True)
+             if prefix:
+                 self.bindir = os.path.join(prefix, 'bin')
+ 
+@@ -427,7 +427,7 @@ class Qt4Dependency(QtBaseDependency):
+         applications = ['moc', 'uic', 'rcc', 'lupdate', 'lrelease']
+         for application in applications:
+             try:
+-                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application, {}))
++                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application, {}, use_native=True))
+             except MesonException:
+                 pass
+ 
+@@ -437,7 +437,7 @@ class Qt5Dependency(QtBaseDependency):
+         QtBaseDependency.__init__(self, 'qt5', env, kwargs)
+ 
+     def get_pkgconfig_host_bins(self, core):
+-        return core.get_pkgconfig_variable('host_bins', {})
++        return core.get_pkgconfig_variable('host_bins', {}, use_native=True)
+ 
+     def get_private_includes(self, mod_inc_dir, module):
+         return _qt_get_private_includes(mod_inc_dir, module, self.version)

--- a/recipes-devtools/meson/meson/disable-rpath-handling.patch
+++ b/recipes-devtools/meson/meson/disable-rpath-handling.patch
@@ -1,0 +1,26 @@
+We need to allow our rpaths generated through the compiler flags to make it into 
+our binaries. Therefore disable the meson manipulations of these unless there
+is a specific directive to do something differently in the project.
+
+RP 2018/11/23
+
+Upstream-Status: Submitted [https://github.com/mesonbuild/meson/issues/2567]
+
+Index: meson-0.47.2/mesonbuild/minstall.py
+===================================================================
+--- meson-0.47.2.orig/mesonbuild/minstall.py
++++ meson-0.47.2/mesonbuild/minstall.py
+@@ -486,8 +486,11 @@ class Installer:
+                         printed_symlink_error = True
+             if os.path.isfile(outname):
+                 try:
+-                    depfixer.fix_rpath(outname, install_rpath, final_path,
+-                                       install_name_mappings, verbose=False)
++                    if install_rpath:
++                        depfixer.fix_rpath(outname, install_rpath, final_path,
++                                           install_name_mappings, verbose=False)
++                    else:
++                        print("RPATH changes at install time disabled")
+                 except SystemExit as e:
+                     if isinstance(e.code, int) and e.code == 0:
+                         pass

--- a/recipes-devtools/meson/meson/gi-flags.patch
+++ b/recipes-devtools/meson/meson/gi-flags.patch
@@ -1,0 +1,35 @@
+Pass the correct cflags/ldflags to the gobject-introspection tools.
+
+Upstream-Status: Submitted [https://github.com/mesonbuild/meson/pull/4261]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index cb69641e..bb4449a0 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -579,7 +579,10 @@ class GnomeModule(ExtensionModule):
+         external_ldflags += list(dep_external_ldflags)
+         scan_command += ['--cflags-begin']
+         scan_command += cflags
+-        scan_command += state.environment.coredata.get_external_args(lang)
++        if state.environment.is_cross_build():
++            scan_command += state.environment.cross_info.config["properties"].get(lang + '_args', "")
++        else:
++            scan_command += state.environment.coredata.get_external_args(lang)
+         scan_command += ['--cflags-end']
+         # need to put our output directory first as we need to use the
+         # generated libraries instead of any possibly installed system/prefix
+@@ -614,7 +614,12 @@ class GnomeModule(ExtensionModule):
+                 scan_command.append('-L' + d)
+             scan_command += ['--library', libname]
+ 
+-        for link_arg in state.environment.coredata.get_external_link_args(lang):
++        if state.environment.is_cross_build():
++            link_args = state.environment.cross_info.config["properties"].get(lang + '_link_args', "")
++        else:
++            link_args = state.environment.coredata.get_external_link_args(lang)
++
++        for link_arg in link_args:
+             if link_arg.startswith('-L'):
+                 scan_command.append(link_arg)
+         scan_command += list(external_ldflags)

--- a/recipes-devtools/meson/meson/gtkdoc-flags.patch
+++ b/recipes-devtools/meson/meson/gtkdoc-flags.patch
@@ -1,0 +1,44 @@
+Ensure that in a cross compile only the target flags are passed to gtk-doc, and
+not the native flags.
+
+Upstream-Status: Submitted [https://github.com/mesonbuild/meson/pull/4261]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/mesonbuild/modules/gnome.py b/mesonbuild/modules/gnome.py
+index 4af33304..8751f53c 100644
+--- a/mesonbuild/modules/gnome.py
++++ b/mesonbuild/modules/gnome.py
+@@ -851,17 +851,30 @@ This will become a hard error in the future.''')
+             if not isinstance(incd.held_object, (str, build.IncludeDirs)):
+                 raise MesonException(
+                     'Gir include dirs should be include_directories().')
++
+         cflags.update(get_include_args(inc_dirs))
+-        cflags.update(state.environment.coredata.get_external_args('c'))
++        if state.environment.is_cross_build():
++            cflags.update(state.environment.cross_info.config["properties"].get('c_args', ""))
++        else:
++            cflags.update(state.environment.coredata.get_external_args('c'))
++
+         ldflags = OrderedSet()
+         ldflags.update(internal_ldflags)
+-        ldflags.update(state.environment.coredata.get_external_link_args('c'))
++        if state.environment.is_cross_build():
++            ldflags.update(state.environment.cross_info.config["properties"].get('c_link_args', ""))
++        else:
++            ldflags.update(state.environment.coredata.get_external_link_args('c'))
+         ldflags.update(external_ldflags)
++
+         if cflags:
+             args += ['--cflags=%s' % ' '.join(cflags)]
+         if ldflags:
+             args += ['--ldflags=%s' % ' '.join(ldflags)]
+-        compiler = state.environment.coredata.compilers.get('c')
++
++        if state.environment.is_cross_build():
++            compiler = state.environment.coredata.cross_compilers.get('c')
++        else:
++            compiler = state.environment.coredata.compilers.get('c')
+         if compiler:
+             args += ['--cc=%s' % ' '.join(compiler.get_exelist())]
+             args += ['--ld=%s' % ' '.join(compiler.get_linker_exelist())]

--- a/recipes-devtools/meson/meson/meson-setup.py
+++ b/recipes-devtools/meson/meson/meson-setup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+def bail(msg):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+_MARKER = '@@'
+def transform_line(line):
+    # Substitute any special markers of this form:
+    # @@ENV@@
+    # with the value of ENV, split into meson array syntax.
+    start = line.find(_MARKER)
+    if start == -1:
+        return line
+
+    end = line.rfind(_MARKER)
+    if end == start:
+        return line
+
+    # Lookup value of the env var.
+    var = line[start+len(_MARKER):end]
+    try:
+        val = os.environ[var]
+    except KeyError:
+        bail('cannot generate meson.cross; env var %s not set' % var)
+
+    # Transform into meson array.
+    val = ["'%s'" % x for x in val.split()]
+    val = ', '.join(val)
+    val = '[%s]' % val
+
+    before = line[:start]
+    after = line[end+len(_MARKER):]
+
+    return '%s%s%s' % (before, val, after)
+
+# Make sure this is really an SDK extraction environment.
+try:
+    sysroot = os.environ['OECORE_NATIVE_SYSROOT']
+except KeyError:
+    bail('OECORE_NATIVE_SYSROOT env var must be set')
+
+cross_file = os.path.join(sysroot, 'usr/share/meson/meson.cross')
+tmp_cross_file = '%s.tmp' % cross_file
+
+# Read through and transform the current meson.cross.
+lines = []
+with open(cross_file, 'r') as f:
+    for line in f:
+        lines.append(transform_line(line))
+
+# Write the transformed result to a tmp file and atomically rename it. In case
+# we crash during the file write, we don't want an invalid meson.cross file.
+with open(tmp_cross_file, 'w') as f:
+    for line in lines:
+        f.write(line)
+    f.flush()
+    os.fdatasync(f.fileno())
+os.rename(tmp_cross_file, cross_file)

--- a/recipes-devtools/meson/meson/meson-wrapper
+++ b/recipes-devtools/meson/meson/meson-wrapper
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$OECORE_NATIVE_SYSROOT" ]; then
+    echo "OECORE_NATIVE_SYSROOT not set; are you in a Yocto SDK environment?" >&2
+fi
+
+# If these are set to a cross-compile path, meson will get confused and try to
+# use them as native tools. Unset them to prevent this, as all the cross-compile
+# config is already in meson.cross.
+unset CC CXX CPP LD AR NM STRIP
+
+exec "$OECORE_NATIVE_SYSROOT/usr/bin/meson.real" \
+     --cross-file "$OECORE_NATIVE_SYSROOT/usr/share/meson/meson.cross" \
+     "$@"

--- a/recipes-devtools/meson/meson_0.47.2.bb
+++ b/recipes-devtools/meson/meson_0.47.2.bb
@@ -1,0 +1,3 @@
+include meson.inc
+
+BBCLASSEXTEND = "native"

--- a/recipes-devtools/meson/nativesdk-meson_0.47.2.bb
+++ b/recipes-devtools/meson/nativesdk-meson_0.47.2.bb
@@ -1,0 +1,74 @@
+include meson.inc
+
+inherit nativesdk
+
+SRC_URI += "file://meson-setup.py \
+            file://meson-wrapper"
+
+def meson_array(var, d):
+    return "', '".join(d.getVar(var).split()).join(("'", "'"))
+
+# both are required but not used by meson
+MESON_SDK_ENDIAN = "bogus-endian"
+MESON_TARGET_ENDIAN = "bogus-endian"
+
+MESON_TOOLCHAIN_ARGS = "${BUILDSDK_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+MESON_C_ARGS = "${MESON_TOOLCHAIN_ARGS} ${BUILDSDK_CFLAGS}"
+MESON_CPP_ARGS = "${MESON_TOOLCHAIN_ARGS} ${BUILDSDK_CXXFLAGS}"
+MESON_LINK_ARGS = "${MESON_TOOLCHAIN_ARGS} ${BUILDSDK_LDFLAGS}"
+
+# This logic is similar but not identical to that in meson.bbclass, since it's
+# generating for an SDK rather than a cross-compile. Important differences are:
+# - We can't set vars like CC, CXX, etc. yet because they will be filled in with
+#   real paths by meson-setup.sh when the SDK is extracted.
+# - Some overrides aren't needed, since the SDK injects paths that take care of
+#   them.
+addtask write_config before do_install
+do_write_config[vardeps] += "MESON_C_ARGS MESON_CPP_ARGS MESON_LINK_ARGS CC CXX LD AR NM STRIP READELF"
+do_write_config() {
+    # This needs to be Py to split the args into single-element lists
+    cat >${WORKDIR}/meson.cross <<EOF
+[binaries]
+c = @@CC@@
+cpp = @@CXX@@
+ar = @@AR@@
+nm = @@NM@@
+ld = @@LD@@
+strip = @@STRIP@@
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+c_args = @@CFLAGS@@
+c_link_args = @@LDFLAGS@@
+cpp_args = @@CPPFLAGS@@
+cpp_link_args = @@LDFLAGS@@
+
+[host_machine]
+system = '${SDK_OS}'
+cpu_family = '${SDK_ARCH}'
+cpu = '${SDK_ARCH}'
+endian = '${MESON_SDK_ENDIAN}'
+EOF
+}
+
+do_install_append() {
+    install -d ${D}${datadir}/meson
+    install -m 0644 ${WORKDIR}/meson.cross ${D}${datadir}/meson/
+
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 ${WORKDIR}/meson-setup.py ${D}${SDKPATHNATIVE}/post-relocate-setup.d/
+
+    # We need to wrap the real meson with a thin env setup wrapper.
+    mv ${D}${bindir}/meson ${D}${bindir}/meson.real
+    install -m 0755 ${WORKDIR}/meson-wrapper ${D}${bindir}/meson
+}
+
+RDEPENDS_${PN} += "\
+    nativesdk-ninja \
+    nativesdk-python3-core \
+    nativesdk-python3-misc \
+    nativesdk-python3-modules \
+    "
+
+FILES_${PN} += "${datadir}/meson ${SDKPATHNATIVE}"

--- a/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
+++ b/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bb
@@ -1,0 +1,49 @@
+SUMMARY = "IGT GPU Tools"
+DESCRIPTION = "IGT GPU Tools is a collection of tools for development and testing of the DRM drivers"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=67bfee4df38fa6ecbe3a675c552d4c08"
+
+LICENSE = "MIT"
+
+inherit meson
+
+SRCREV = "d16ad07e7f2a028e14d61f570931c87fa5ce404c"
+PV = "1.25+git${SRCPV}"
+
+SRC_URI = "git://gitlab.freedesktop.org/drm/igt-gpu-tools.git;protocol=https"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "libdrm libpciaccess cairo udev glib-2.0 procps libunwind kmod openssl elfutils alsa-lib json-c bison-native"
+RDEPENDS_${PN} += "bash"
+RDEPENDS_${PN}-tests += "bash"
+
+PACKAGE_BEFORE_PN = "${PN}-benchmarks ${PN}-tests"
+
+PACKAGECONFIG[chamelium] = "-Dchamelium=enabled,-Dchamelium=disabled,gsl xmlrpc-c"
+
+EXTRA_OEMESON = "-Ddocs=disabled -Drunner=enabled"
+COMPATIBLE_HOST = "(x86_64.*|i.86.*|arm.*|aarch64).*-linux"
+COMPATIBLE_HOST_libc-musl_class-target = "null"
+SECURITY_LDFLAGS = "${SECURITY_X_LDFLAGS}"
+
+gputools_sysroot_preprocess() {
+	rm -f ${SYSROOT_DESTDIR}${libdir}/pkgconfig/intel-gen4asm.pc
+}
+SYSROOT_PREPROCESS_FUNCS += "gputools_sysroot_preprocess"
+
+do_install_append() {
+    install -d ${D}/usr/share/${BPN}/scripts
+    install ${S}/scripts/run-tests.sh ${D}/usr/share/${BPN}/scripts
+    install -d ${D}/usr/share/${BPN}/runner
+    install -D ${B}/runner/igt_runner ${D}/usr/share/${BPN}/runner
+    install -D ${B}/runner/igt_resume ${D}/usr/share/${BPN}/runner
+}
+
+FILES_${PN}-benchmarks += "${libexecdir}/${BPN}/benchmarks"
+FILES_${PN}-tests += "\
+        ${libexecdir}/${BPN}/*\
+        ${datadir}/${BPN}/1080p-right.png\
+        ${datadir}/${BPN}/1080p-left.png\
+        ${datadir}/${BPN}/pass.png\
+        ${datadir}/${BPN}/test-list.txt"

--- a/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bbappend
+++ b/recipes-graphics/igt-gpu-tools/igt-gpu-tools_git.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append = " chamelium"

--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -8,6 +8,9 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     git \
     grep \
     haveged \
+    igt-gpu-tools \
+    igt-gpu-tools-benchmarks \
+    igt-gpu-tools-tests \
     jq \
     kernel-selftests \
     kselftests-mainline \


### PR DESCRIPTION
These patches add support for the Chamelium board in our builds.

The main package, igt-gpu-tools, require a newer version of Meson that is not available on Sumo. The one provided by Thud is recent enough and works fine.