### PR TITLE
Fix i386 build problem due to incomplete Meson

### DIFF
--- a/classes/meson.bbclass
+++ b/classes/meson.bbclass
@@ -1,0 +1,158 @@
+inherit siteinfo python3native
+
+DEPENDS_append = " meson-native ninja-native"
+
+# As Meson enforces out-of-tree builds we can just use cleandirs
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+# Where the meson.build build configuration is
+MESON_SOURCEPATH = "${S}"
+
+def noprefix(var, d):
+    return d.getVar(var).replace(d.getVar('prefix') + '/', '', 1)
+
+MESONOPTS = " --prefix ${prefix} \
+              --buildtype plain \
+              --bindir ${@noprefix('bindir', d)} \
+              --sbindir ${@noprefix('sbindir', d)} \
+              --datadir ${@noprefix('datadir', d)} \
+              --libdir ${@noprefix('libdir', d)} \
+              --libexecdir ${@noprefix('libexecdir', d)} \
+              --includedir ${@noprefix('includedir', d)} \
+              --mandir ${@noprefix('mandir', d)} \
+              --infodir ${@noprefix('infodir', d)} \
+              --sysconfdir ${sysconfdir} \
+              --localstatedir ${localstatedir} \
+              --sharedstatedir ${sharedstatedir} \
+              -Dc_args='${BUILD_CPPFLAGS} ${BUILD_CFLAGS}' \
+              -Dc_link_args='${BUILD_LDFLAGS}' \
+              -Dcpp_args='${BUILD_CPPFLAGS} ${BUILD_CXXFLAGS}' \
+              -Dcpp_link_args='${BUILD_LDFLAGS}'"
+
+MESON_TOOLCHAIN_ARGS = "${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS}"
+MESON_C_ARGS = "${MESON_TOOLCHAIN_ARGS} ${CFLAGS}"
+MESON_CPP_ARGS = "${MESON_TOOLCHAIN_ARGS} ${CXXFLAGS}"
+MESON_LINK_ARGS = "${MESON_TOOLCHAIN_ARGS} ${LDFLAGS}"
+
+EXTRA_OEMESON_append = " ${PACKAGECONFIG_CONFARGS}"
+
+MESON_CROSS_FILE = ""
+MESON_CROSS_FILE_class-target = "--cross-file ${WORKDIR}/meson.cross"
+MESON_CROSS_FILE_class-nativesdk = "--cross-file ${WORKDIR}/meson.cross"
+
+def meson_array(var, d):
+    items = d.getVar(var).split()
+    return repr(items[0] if len(items) == 1 else items)
+
+# Map our ARCH values to what Meson expects:
+# http://mesonbuild.com/Reference-tables.html#cpu-families
+def meson_cpu_family(var, d):
+    import re
+    arch = d.getVar(var)
+    if arch == 'powerpc':
+        return 'ppc'
+    elif arch == 'powerpc64':
+        return 'ppc64'
+    elif arch == 'mipsel':
+        return 'mips'
+    elif re.match(r"i[3-6]86", arch):
+        return "x86"
+    else:
+        return arch
+
+def meson_endian(prefix, d):
+    arch, os = d.getVar(prefix + "_ARCH"), d.getVar(prefix + "_OS")
+    sitedata = siteinfo_data_for_machine(arch, os, d)
+    if "endian-little" in sitedata:
+        return "little"
+    elif "endian-big" in sitedata:
+        return "big"
+    else:
+        bb.fatal("Cannot determine endianism for %s-%s" % (arch, os))
+
+addtask write_config before do_configure
+do_write_config[vardeps] += "MESON_C_ARGS MESON_CPP_ARGS MESON_LINK_ARGS CC CXX LD AR NM STRIP READELF"
+do_write_config() {
+    # This needs to be Py to split the args into single-element lists
+    cat >${WORKDIR}/meson.cross <<EOF
+[binaries]
+c = ${@meson_array('CC', d)}
+cpp = ${@meson_array('CXX', d)}
+ar = ${@meson_array('AR', d)}
+nm = ${@meson_array('NM', d)}
+ld = ${@meson_array('LD', d)}
+strip = ${@meson_array('STRIP', d)}
+readelf = ${@meson_array('READELF', d)}
+pkgconfig = 'pkg-config'
+
+[properties]
+needs_exe_wrapper = true
+c_args = ${@meson_array('MESON_C_ARGS', d)}
+c_link_args = ${@meson_array('MESON_LINK_ARGS', d)}
+cpp_args = ${@meson_array('MESON_CPP_ARGS', d)}
+cpp_link_args = ${@meson_array('MESON_LINK_ARGS', d)}
+gtkdoc_exe_wrapper = '${B}/gtkdoc-qemuwrapper'
+
+[host_machine]
+system = '${HOST_OS}'
+cpu_family = '${@meson_cpu_family('HOST_ARCH', d)}'
+cpu = '${HOST_ARCH}'
+endian = '${@meson_endian('HOST', d)}'
+
+[target_machine]
+system = '${TARGET_OS}'
+cpu_family = '${@meson_cpu_family('TARGET_ARCH', d)}'
+cpu = '${TARGET_ARCH}'
+endian = '${@meson_endian('TARGET', d)}'
+EOF
+}
+
+CONFIGURE_FILES = "meson.build"
+
+meson_do_configure() {
+    # Work around "Meson fails if /tmp is mounted with noexec #2972"
+    mkdir -p "${B}/meson-private/tmp"
+    export TMPDIR="${B}/meson-private/tmp"
+    bbnote Executing meson ${EXTRA_OEMESON}...
+    if ! meson ${MESONOPTS} "${MESON_SOURCEPATH}" "${B}" ${MESON_CROSS_FILE} ${EXTRA_OEMESON}; then
+        bbfatal_log meson failed
+    fi
+}
+
+override_native_tools() {
+    # Set these so that meson uses the native tools for its build sanity tests,
+    # which require executables to be runnable. The cross file will still
+    # override these for the target build.
+    export CC="${BUILD_CC}"
+    export CXX="${BUILD_CXX}"
+    export LD="${BUILD_LD}"
+    export AR="${BUILD_AR}"
+    # These contain *target* flags but will be used as *native* flags.  The
+    # correct native flags will be passed via -Dc_args and so on, unset them so
+    # they don't interfere with tools invoked by Meson (such as g-ir-scanner)
+    unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS
+}
+
+meson_do_configure_prepend_class-target() {
+    override_native_tools
+}
+
+meson_do_configure_prepend_class-nativesdk() {
+    override_native_tools
+}
+
+meson_do_configure_prepend_class-native() {
+    export PKG_CONFIG="pkg-config-native"
+}
+
+do_compile[progress] = "outof:^\[(\d+)/(\d+)\]\s+"
+meson_do_compile() {
+    ninja -v ${PARALLEL_MAKE}
+}
+
+meson_do_install() {
+    DESTDIR='${D}' ninja -v ${PARALLEL_MAKEINST} install
+}
+
+EXPORT_FUNCTIONS do_configure do_compile do_install

--- a/classes/siteinfo.bbclass
+++ b/classes/siteinfo.bbclass
@@ -1,0 +1,199 @@
+# This class exists to provide information about the targets that
+# may be needed by other classes and/or recipes. If you add a new
+# target this will probably need to be updated.
+
+#
+# Returns information about 'what' for the named target 'target'
+# where 'target' == "<arch>-<os>"
+#
+# 'what' can be one of
+# * target: Returns the target name ("<arch>-<os>")
+# * endianness: Return "be" for big endian targets, "le" for little endian
+# * bits: Returns the bit size of the target, either "32" or "64"
+# * libc: Returns the name of the c library used by the target
+#
+# It is an error for the target not to exist.
+# If 'what' doesn't exist then an empty value is returned
+#
+def siteinfo_data_for_machine(arch, os, d):
+    archinfo = {
+        "allarch": "endian-little bit-32", # bogus, but better than special-casing the checks below for allarch
+        "aarch64": "endian-little bit-64 arm-common arm-64",
+        "aarch64_be": "endian-big bit-64 arm-common arm-64",
+        "arc": "endian-little bit-32 arc-common",
+        "arceb": "endian-big bit-32 arc-common",
+        "arm": "endian-little bit-32 arm-common arm-32",
+        "armeb": "endian-big bit-32 arm-common arm-32",
+        "avr32": "endian-big bit-32 avr32-common",
+        "bfin": "endian-little bit-32 bfin-common",
+        "epiphany": "endian-little bit-32",
+        "i386": "endian-little bit-32 ix86-common",
+        "i486": "endian-little bit-32 ix86-common",
+        "i586": "endian-little bit-32 ix86-common",
+        "i686": "endian-little bit-32 ix86-common",
+        "ia64": "endian-little bit-64",
+        "lm32": "endian-big bit-32",
+        "m68k": "endian-big bit-32",
+        "microblaze": "endian-big bit-32 microblaze-common",
+        "microblazeeb": "endian-big bit-32 microblaze-common",
+        "microblazeel": "endian-little bit-32 microblaze-common",
+        "mips": "endian-big bit-32 mips-common",
+        "mips64": "endian-big bit-64 mips-common",
+        "mips64el": "endian-little bit-64 mips-common",
+        "mipsisa64r6": "endian-big bit-64 mips-common",
+        "mipsisa64r6el": "endian-little bit-64 mips-common",
+        "mipsel": "endian-little bit-32 mips-common",
+        "mipsisa32r6": "endian-big bit-32 mips-common",
+        "mipsisa32r6el": "endian-little bit-32 mips-common",
+        "powerpc": "endian-big bit-32 powerpc-common",
+        "nios2": "endian-little bit-32 nios2-common",
+        "powerpc64": "endian-big bit-64 powerpc-common",
+        "ppc": "endian-big bit-32 powerpc-common",
+        "ppc64": "endian-big bit-64 powerpc-common",
+        "ppc64le" : "endian-little bit-64 powerpc-common",
+        "riscv32": "endian-little bit-32 riscv-common",
+        "riscv64": "endian-little bit-64 riscv-common",
+        "sh3": "endian-little bit-32 sh-common",
+        "sh4": "endian-little bit-32 sh-common",
+        "sparc": "endian-big bit-32",
+        "viac3": "endian-little bit-32 ix86-common",
+        "x86_64": "endian-little", # bitinfo specified in targetinfo
+    }
+    osinfo = {
+        "darwin": "common-darwin",
+        "darwin9": "common-darwin",
+        "linux": "common-linux common-glibc",
+        "linux-gnu": "common-linux common-glibc",
+        "linux-gnu_ilp32": "common-linux common-glibc",
+        "linux-gnux32": "common-linux common-glibc",
+        "linux-gnun32": "common-linux common-glibc",
+        "linux-gnueabi": "common-linux common-glibc",
+        "linux-gnuspe": "common-linux common-glibc",
+        "linux-musl": "common-linux common-musl",
+        "linux-muslx32": "common-linux common-musl",
+        "linux-musleabi": "common-linux common-musl",
+        "linux-muslspe": "common-linux common-musl",
+        "uclinux-uclibc": "common-uclibc",
+        "cygwin": "common-cygwin",
+        "mingw32": "common-mingw",
+    }
+    targetinfo = {
+        "aarch64-linux-gnu": "aarch64-linux",
+        "aarch64_be-linux-gnu": "aarch64_be-linux",
+        "aarch64-linux-gnu_ilp32": "bit-32 aarch64_be-linux arm-32",
+        "aarch64_be-linux-gnu_ilp32": "bit-32 aarch64_be-linux arm-32",
+        "aarch64-linux-musl": "aarch64-linux",
+        "aarch64_be-linux-musl": "aarch64_be-linux",
+        "arm-linux-gnueabi": "arm-linux",
+        "arm-linux-musleabi": "arm-linux",
+        "armeb-linux-gnueabi": "armeb-linux",
+        "armeb-linux-musleabi": "armeb-linux",
+        "microblazeeb-linux" : "microblaze-linux",
+        "microblazeeb-linux-musl" : "microblaze-linux",
+        "microblazeel-linux" : "microblaze-linux",
+        "microblazeel-linux-musl" : "microblaze-linux",
+        "mips-linux-musl": "mips-linux",
+        "mipsel-linux-musl": "mipsel-linux",
+        "mips64-linux-musl": "mips64-linux",
+        "mips64el-linux-musl": "mips64el-linux",
+        "mips64-linux-gnun32": "mips-linux bit-32",
+        "mips64el-linux-gnun32": "mipsel-linux bit-32",
+        "mipsisa64r6-linux-gnun32": "mipsisa32r6-linux bit-32",
+        "mipsisa64r6el-linux-gnun32": "mipsisa32r6el-linux bit-32",
+        "powerpc-linux": "powerpc32-linux",
+        "powerpc-linux-musl": "powerpc-linux powerpc32-linux",
+        "powerpc-linux-gnuspe": "powerpc-linux powerpc32-linux",
+        "powerpc-linux-muslspe": "powerpc-linux powerpc32-linux",
+        "powerpc64-linux-gnuspe": "powerpc-linux powerpc64-linux",
+        "powerpc64-linux-muslspe": "powerpc-linux powerpc64-linux",
+        "powerpc64-linux": "powerpc-linux",
+        "powerpc64-linux-musl": "powerpc-linux",
+        "riscv32-linux": "riscv32-linux",
+        "riscv32-linux-musl": "riscv32-linux",
+        "riscv64-linux": "riscv64-linux",
+        "riscv64-linux-musl": "riscv64-linux",
+        "x86_64-cygwin": "bit-64",
+        "x86_64-darwin": "bit-64",
+        "x86_64-darwin9": "bit-64",
+        "x86_64-linux": "bit-64",
+        "x86_64-linux-musl": "x86_64-linux bit-64",
+        "x86_64-linux-muslx32": "bit-32 ix86-common x32-linux",
+        "x86_64-elf": "bit-64",
+        "x86_64-linux-gnu": "bit-64 x86_64-linux",
+        "x86_64-linux-gnux32": "bit-32 ix86-common x32-linux",
+        "x86_64-mingw32": "bit-64",
+    }
+
+    # Add in any extra user supplied data which may come from a BSP layer, removing the
+    # need to always change this class directly
+    extra_siteinfo = (d.getVar("SITEINFO_EXTRA_DATAFUNCS") or "").split()
+    for m in extra_siteinfo:
+        call = m + "(archinfo, osinfo, targetinfo, d)"
+        locs = { "archinfo" : archinfo, "osinfo" : osinfo, "targetinfo" : targetinfo, "d" : d}
+        archinfo, osinfo, targetinfo = bb.utils.better_eval(call, locs)
+
+    target = "%s-%s" % (arch, os)
+
+    sitedata = []
+    if arch in archinfo:
+        sitedata.extend(archinfo[arch].split())
+    if os in osinfo:
+        sitedata.extend(osinfo[os].split())
+    if target in targetinfo:
+        sitedata.extend(targetinfo[target].split())
+    sitedata.append(target)
+    sitedata.append("common")
+
+    bb.debug(1, "SITE files %s" % sitedata);
+    return sitedata
+
+def siteinfo_data(d):
+    return siteinfo_data_for_machine(d.getVar("HOST_ARCH"), d.getVar("HOST_OS"), d)
+
+python () {
+    sitedata = set(siteinfo_data(d))
+    if "endian-little" in sitedata:
+        d.setVar("SITEINFO_ENDIANNESS", "le")
+    elif "endian-big" in sitedata:
+        d.setVar("SITEINFO_ENDIANNESS", "be")
+    else:
+        bb.error("Unable to determine endianness for architecture '%s'" %
+                 d.getVar("HOST_ARCH"))
+        bb.fatal("Please add your architecture to siteinfo.bbclass")
+
+    if "bit-32" in sitedata:
+        d.setVar("SITEINFO_BITS", "32")
+    elif "bit-64" in sitedata:
+        d.setVar("SITEINFO_BITS", "64")
+    else:
+        bb.error("Unable to determine bit size for architecture '%s'" %
+                 d.getVar("HOST_ARCH"))
+        bb.fatal("Please add your architecture to siteinfo.bbclass")
+}
+
+def siteinfo_get_files(d, sysrootcache = False):
+    sitedata = siteinfo_data(d)
+    sitefiles = ""
+    for path in d.getVar("BBPATH").split(":"):
+        for element in sitedata:
+            filename = os.path.join(path, "site", element)
+            if os.path.exists(filename):
+                sitefiles += filename + " "
+
+    if not sysrootcache:
+        return sitefiles
+
+    # Now check for siteconfig cache files in sysroots
+    path_siteconfig = d.getVar('SITECONFIG_SYSROOTCACHE')
+    if path_siteconfig and os.path.isdir(path_siteconfig):
+        for i in os.listdir(path_siteconfig):
+            if not i.endswith("_config"):
+                continue
+            filename = os.path.join(path_siteconfig, i)
+            sitefiles += filename + " "
+    return sitefiles
+
+#
+# Make some information available via variables
+#
+SITECONFIG_SYSROOTCACHE = "${STAGING_DATADIR}/${TARGET_SYS}_config_site.d"


### PR DESCRIPTION
The recent import of the newer Meson recipe was incomplete, as it should have been done in tandem with the update of the Meson bbclass. This imports that class and its dependency on siteinfo.