### PR TITLE
linux: Remove TRANSPARENT_HUGEPAGE_ALWAYS config fragment

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -100,7 +100,6 @@ CONFIG_QEDE=y
 # Enable for selftest kvm tests
 # https://bugs.linaro.org/show_bug.cgi?id=3780
 CONFIG_TRANSPARENT_HUGEPAGE=y
-CONFIG_TRANSPARENT_HUGEPAGE_ALWAYS=y
 CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y
 
 # For igt Chamelium test


### PR DESCRIPTION
When TRANSPARENT_HUGEPAGE_MADVISE=y is enabled the other config do not make
sense so removing TRANSPARENT_HUGEPAGE_ALWAYS=y

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>