### PR TITLE
linux: Adding kunit test config fragments

### DIFF
--- a/recipes-kernel/linux/files/lkft-kunit.config
+++ b/recipes-kernel/linux/files/lkft-kunit.config
@@ -1,0 +1,6 @@
+#
+# Kunit
+# Found in Linux kernels: 5.8 and above
+# Enable these configs only on 5.8 and above
+CONFIG_KUNIT=y
+CONFIG_KUNIT_ALL_TESTS=y


### PR DESCRIPTION
Enables all KUnit tests, if they can be enabled. KUnit tests run during boot
and output the results to the debug log in TAP format.
Only useful for kernel devs running the KUnit test harness, and not intended
for inclusion into a production build.

ref:
Investigate adding KUnit to LKFT
https://projects.linaro.org/browse/LKQ-266

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>