### PR TITLE
images: Add X15's limitation for extra rootfs space again

### DIFF
--- a/recipes-samples/images/rpb-console-image-lkft.bb
+++ b/recipes-samples/images/rpb-console-image-lkft.bb
@@ -4,6 +4,10 @@ SUMMARY = "Basic console image for LKFT"
 
 IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
 
+# Add 512 MB on X15; more than that might exceed the
+# userdata partition capacity.
+IMAGE_ROOTFS_EXTRA_SPACE_am57xx-evm = "524288"
+
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-rpb-tests \
     packagegroup-rpb-lkft \


### PR DESCRIPTION
As of recently, a change in the partition table of the X15's means that we are now able to use a much larger partition, as mentioned in e62f7600a3bb ("images: Remove X15's limitation for extra rootfs space"), but apparently not too much: adding 1 GB puts us back on the edge of exceeding the partition size.

Putting this limitation here would provide more than enough space for scratch while giving us ample room to work with given the partition size of the X15.