### PR TITLE
linux: Add MPTCP config

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -153,3 +153,7 @@ CONFIG_MODULE_UNLOAD=y
 CONFIG_KALLSYMS_ALL=y
 # LTP tracing dynamic_debug01 needs this config fragment
 CONFIG_DYNAMIC_DEBUG=y
+
+# Multipath TCP
+# https://lore.kernel.org/netdev/20190617225808.665-1-mathew.j.martineau@linux.intel.com/
+CONFIG_MPTCP=y


### PR DESCRIPTION
This enables multipath TCP testing from recent kselftests.