### PR TITLE
kselftests: Add iproute2-ss run-time dependency

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -38,7 +38,7 @@ FILES_${KERNEL_PACKAGE_NAME}-selftests += "${KST_INSTALL_PATH}/bpf/*.o"
 PACKAGES =+ "kernel-selftests-dbg"
 FILES_${KERNEL_PACKAGE_NAME}-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-tc iputils-ping ncurses nftables perl sudo"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping ncurses nftables perl sudo"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_x86 = " cpupower"

--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -32,7 +32,7 @@ FILES_${PN} = "${INSTALL_PATH}"
 FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-tc iputils-ping ncurses nftables perl sudo"
+RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping ncurses nftables perl sudo"
 RDEPENDS_${PN} =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${PN} =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"


### PR DESCRIPTION
This is used by some tests, like the mptcp ones.