### PR TITLE
Add netsniff-ng

### DIFF
--- a/recipes-connectivity/libcli/files/make-build-tools-overridable.patch
+++ b/recipes-connectivity/libcli/files/make-build-tools-overridable.patch
@@ -1,0 +1,40 @@
+From 6ea34a60add4b60e1f03e59aee440f3d0882cdd5 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20D=C3=ADaz?= <daniel.diaz@linaro.org>
+Date: Fri, 29 May 2020 11:58:18 -0500
+Subject: [PATCH] Make build tools overridable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ Makefile | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e90e144..597d2c7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,7 +7,7 @@ TESTS ?= 1
+ 
+ UNAME = $(shell sh -c 'uname -s 2>/dev/null || echo not')
+ DESTDIR =
+-PREFIX = /usr/local
++PREFIX ?= /usr/local
+ 
+ MAJOR = 1
+ MINOR = 10
+@@ -15,8 +15,8 @@ REVISION = 4
+ LIB = libcli.so
+ LIB_STATIC = libcli.a
+ 
+-CC = gcc
+-AR = ar
++CC ?= gcc
++AR ?= ar
+ ARFLAGS = rcs
+ DEBUG = -g
+ OPTIM = -O3
+-- 
+2.20.1
+

--- a/recipes-connectivity/libcli/libcli_1.10.4.bb
+++ b/recipes-connectivity/libcli/libcli_1.10.4.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Libcli is a shared library for a Cisco-like command-line interface"
+DESCRIPTION = "Libcli provides a shared library for including a Cisco-like command-line interface into other software."
+HOMEPAGE = "https://dparrish.com/pages/libcli"
+SECTION = "console/devel"
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=cb8aedd3bced19bd8026d96a8b6876d7"
+
+DEPENDS = "virtual/crypt"
+
+SRCREV = "4ef06297a2b056a5841de3e3bfa6cc43ac46e7b3"
+SRC_URI = "git://github.com/dparrish/libcli.git;protocol=https;branch=stable \
+    file://make-build-tools-overridable.patch \
+"
+
+S = "${WORKDIR}/git"
+
+do_compile() {
+    oe_runmake #'CC=${CC}' 'LD=${LD}' 'LDFLAGS=${LDFLAGS}'
+}
+
+do_install() {
+    oe_runmake PREFIX=${D}/${prefix} install
+}
+
+FILES_${PN} = "${libdir}"

--- a/recipes-connectivity/netsniff-ng/netsniff-ng_0.6.7.bb
+++ b/recipes-connectivity/netsniff-ng/netsniff-ng_0.6.7.bb
@@ -1,0 +1,42 @@
+SUMMARY = "netsniff-ng is a Swiss army knife for your daily Linux network plumbing"
+DESCRIPTION = "netsniff-ng is a free, performant Linux network analyzer and networking toolkit. If you will, the Swiss army knife for network packets."
+HOMEPAGE = "http://netsniff-ng.org/"
+SECTION = "console/utils"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=9dd40dfb621eed702c0775577fbb7011"
+
+DEPENDS = "bison \
+    flex \
+    libcli \
+    libnet \
+    libpcap \
+    ncurses \
+"
+
+SRCREV = "4c641508fbc500e57b55609b60b17870c158c70c"
+SRC_URI = "git://github.com/netsniff-ng/netsniff-ng.git;protocol=https"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig
+
+PACKAGECONFIG ??= "libnl zlib"
+PACKAGECONFIG[libnl] = "--enable-libnl,--disable-libnl,libnl"
+PACKAGECONFIG[geoip] = "--enable-geoip,--disable-geoip,geoip"
+PACKAGECONFIG[zlib] = "--enable-zlib,--disable-zlib,zlib"
+
+do_configure() {
+    ${S}/configure ${CONFIGUREOPTS} --prefix=${D}${prefix}
+}
+
+do_compile() {
+    oe_runmake 'CC=${CC}' 'LD=${LD}' 'LDFLAGS=${LDFLAGS}'
+}
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -d -m 0700 ${D}${sysconfdir}/netsniff-ng
+    oe_runmake ETCDIR=${D}${sysconfdir} install
+}
+
+FILES_${PN} = "${sbindir} ${sysconfdir} ${datadir}"

--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -38,7 +38,7 @@ FILES_${KERNEL_PACKAGE_NAME}-selftests += "${KST_INSTALL_PATH}/bpf/*.o"
 PACKAGES =+ "kernel-selftests-dbg"
 FILES_${KERNEL_PACKAGE_NAME}-selftests-dbg = "${KST_INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping ncurses nftables perl sudo"
+RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping netsniff-ng ncurses nftables perl sudo"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-selftests_append_x86 = " cpupower"

--- a/recipes-overlayed/kselftests/kselftests-common.inc
+++ b/recipes-overlayed/kselftests/kselftests-common.inc
@@ -32,7 +32,7 @@ FILES_${PN} = "${INSTALL_PATH}"
 FILES_${PN} += "${INSTALL_PATH}/bpf/*.o"
 FILES_${PN}-dbg = "${INSTALL_PATH}/*/.debug /usr/src/debug/*"
 
-RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping ncurses nftables perl sudo"
+RDEPENDS_${PN} = "bash bc ethtool fuse-utils iproute2 iproute2-nstat iproute2-ss iproute2-tc iputils-ping netsniff-ng ncurses nftables perl sudo"
 RDEPENDS_${PN} =+ "python3-core python3-datetime python3-json python3-pprint"
 RDEPENDS_${PN} =+ "util-linux-lscpu util-linux-uuidgen"
 RDEPENDS_${PN}_append_x86 = " cpupower"


### PR DESCRIPTION
Add one recipe for `netsniff-ng` and another for its dependency, libcli. These two are needed in kselftests so that net/forwarding tests can be executed.