### PR TITLE
packagegroup: Restrict fwts to non arm

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -5,7 +5,7 @@ inherit packagegroup
 # contains basic dependencies for LKFT
 RDEPENDS_packagegroup-rpb-lkft = "\
     android-kernel-tests \
-    fwts \
+    ${@bb.utils.contains("TUNE_ARCH", "arm", "", "fwts", d)} \
     git \
     grep \
     haveged \


### PR DESCRIPTION
The package fwts is not compatible with arm 32-bits machines, such as X15 or Beaglebone, where it errors out like this:
```
fwts was skipped: incompatible with host arm-linaro-linux-gnueabi (not in COMPATIBLE_HOST)
```