### PR TITLE
Debian Buster updates

### DIFF
--- a/meta/recipes-devtools/bison/bison/gnulib.patch
+++ b/meta/recipes-devtools/bison/bison/gnulib.patch
@@ -1,0 +1,21 @@
+Fix gnulib issues found with glibc 2.28 libio.h removal
+
+see
+https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
+Index: bison-3.0.4/lib/fseterr.c
+===================================================================
+--- bison-3.0.4.orig/lib/fseterr.c
++++ bison-3.0.4/lib/fseterr.c
+@@ -29,7 +29,7 @@ fseterr (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin */
+   fp_->_flags |= __SERR;

--- a/recipes-core/glibc/cross-localedef-native_2.27.bbappend
+++ b/recipes-core/glibc/cross-localedef-native_2.27.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://0032-argp-do-not-call-_IO_fwide-if-_LIBC-is-not-defined.patch"

--- a/recipes-core/glibc/files/0032-argp-do-not-call-_IO_fwide-if-_LIBC-is-not-defined.patch
+++ b/recipes-core/glibc/files/0032-argp-do-not-call-_IO_fwide-if-_LIBC-is-not-defined.patch
@@ -1,0 +1,78 @@
+From 3a67e81d7527363a96af095a5af03b6201b82e9d Mon Sep 17 00:00:00 2001
+From: Charles-Antoine Couret <charles-antoine.couret@essensium.com>
+Date: Thu, 29 Nov 2018 17:56:55 +0000
+Subject: [PATCH] argp: do not call _IO_fwide() if _LIBC is not defined
+
+_IO_fwide() is defined in libio.h file. This file is included only
+when _LIBC is defined.
+
+So, in case of compilation of these files without _LIBC definition,
+the compilation failed due to this unknown function.
+
+Now this function is called when libio.h file is included.
+
+(Change merged from gnulib.  Tested on x86_64.)
+
+	* argp/argp-fmtstream.c (__argp_fmtstream_update): Use [_LIBC]
+	conditional on calls to _IO_fwide and putwc_unlocked.  (Merge from
+	gnulib.)
+	* argp/argp-help.c (__argp_failure): Likewise.
+	
+Upstream-Status: Backport [1]
+
+[1] https://sourceware.org/git/?p=glibc.git;a=commit;h=3a67e81d7527363a96af095a5af03b6201b82e9d
+
+Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+---
+ ChangeLog             | 7 +++++++
+ argp/argp-fmtstream.c | 4 ++++
+ argp/argp-help.c      | 2 ++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/argp/argp-fmtstream.c b/argp/argp-fmtstream.c
+index e43a0c7cf1..e9e4c0e5cc 100644
+--- a/argp/argp-fmtstream.c
++++ b/argp/argp-fmtstream.c
+@@ -149,9 +149,11 @@ __argp_fmtstream_update (argp_fmtstream_t fs)
+ 	      size_t i;
+ 	      for (i = 0; i < pad; i++)
+ 		{
++#ifdef _LIBC
+ 		  if (_IO_fwide (fs->stream, 0) > 0)
+ 		    putwc_unlocked (L' ', fs->stream);
+ 		  else
++#endif
+ 		    putc_unlocked (' ', fs->stream);
+ 		}
+ 	    }
+@@ -312,9 +314,11 @@ __argp_fmtstream_update (argp_fmtstream_t fs)
+ 	      *nl++ = ' ';
+ 	  else
+ 	    for (i = 0; i < fs->wmargin; ++i)
++#ifdef _LIBC
+ 	      if (_IO_fwide (fs->stream, 0) > 0)
+ 		putwc_unlocked (L' ', fs->stream);
+ 	      else
++#endif
+ 		putc_unlocked (' ', fs->stream);
+ 
+ 	  /* Copy the tail of the original buffer into the current buffer
+diff --git a/argp/argp-help.c b/argp/argp-help.c
+index 2b6b0775d6..a17260378c 100644
+--- a/argp/argp-help.c
++++ b/argp/argp-help.c
+@@ -1873,9 +1873,11 @@ __argp_failure (const struct argp_state *state, int status, int errnum,
+ #endif
+ 	    }
+ 
++#ifdef _LIBC
+ 	  if (_IO_fwide (stream, 0) > 0)
+ 	    putwc_unlocked (L'\n', stream);
+ 	  else
++#endif
+ 	    putc_unlocked ('\n', stream);
+ 
+ #if _LIBC || (HAVE_FLOCKFILE && HAVE_FUNLOCKFILE)
+-- 
+2.21.0
+

--- a/recipes-devtools/bison/bison_3.0.4.bbappend
+++ b/recipes-devtools/bison/bison_3.0.4.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://gnulib.patch"


### PR DESCRIPTION
There are some failures while building Sumo on newer versions of Debian (and other host OS's). There is a series of 4 patches to deal with this problem, though it looks like we only need 2 of them:
* [elfutils(-native): Add backported patch to fix build with host gcc9](https://patchwork.openembedded.org/patch/165261/)
* [bison: Fix build break with glibc 2.28](https://patchwork.openembedded.org/patch/165262/)
* [glib-2.0: Add patch from upstream to fix build with host gcc9](https://patchwork.openembedded.org/patch/165263/)
* [cross-localedef-native: Fix build for hosts with recent glibc](https://patchwork.openembedded.org/patch/165264/)

Should we need more patches from that series, they'll come in a follow-up pull-request.

The error manifests itself like this:
```
../bison-3.0.4/lib/fseterr.c: In function 'fseterr':
../bison-3.0.4/lib/fseterr.c:77:3: error: #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."
  #error "Please port gnulib fseterr.c to your platform! Look at the definitions of ferror and clearerr on your system, then report this to bug-gnulib."
   ^~~~~
gcc     -I. -I./lib -I../bison-3.0.4 -I../bison-3.0.4/lib -isystem/srv/oe/build/tmp-lkft-glibc/work/x86_64-linux/bison-native/3.0.4-r0/recipe-sysroot-native/usr/include  -isystem/srv/oe/build/tmp-lkft-glibc/work/x86_64-linux/bison-native/3.0.4-r0/recipe-sysroot-native/usr/include -O2 -pipe -c -o lib/isnanl.o ../bison-3.0.4/lib/isnanl.c
make[2]: *** [Makefile:3366: lib/fseterr.o] Error 1
```

Our CI was previously building with Debian Stretch.