### PR TITLE
linux-next: remove sm8350 from deploy on mainline, next and generic

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -109,7 +109,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* *sm8350* ) || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -109,7 +109,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* *sm8350* ) || true
 }
 
 require machine-specific-hooks.inc

--- a/recipes-kernel/linux/linux-generic_git.bb
+++ b/recipes-kernel/linux/linux-generic_git.bb
@@ -116,7 +116,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* *sm8350* ) || true
 }
 
 python do_package_prepend() {


### PR DESCRIPTION
17:46:52 | Traceback (most recent call last):
17:46:52 |   File "/srv/oe/build/tmp-lkft-glibc/work/dragonboard_410c-linaro-linux/linux-generic-next/5.10+gitAUTOINC+8d374d0d44-r0/recipe-sysroot-native/usr/bin/skales/dtbTool", line 433, in <module>
17:46:52 |     records += generate_records(f, pagesize)
17:46:52 |   File "/srv/oe/build/tmp-lkft-glibc/work/dragonboard_410c-linaro-linux/linux-generic-next/5.10+gitAUTOINC+8d374d0d44-r0/recipe-sysroot-native/usr/bin/skales/dtbTool", line 386, in generate_records
17:46:52 |     if QcomIds.pattern.match(compat)]
17:46:52 |   File "/srv/oe/build/tmp-lkft-glibc/work/dragonboard_410c-linaro-linux/linux-generic-next/5.10+gitAUTOINC+8d374d0d44-r0/recipe-sysroot-native/usr/bin/skales/dtbTool", line 239, in __init__
17:46:52 |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
17:46:52 | KeyError: u'sm8350'
17:46:52 | WARNING: exit code 1 from a shell command.
17:46:52 | ERROR: Function failed: do_deploy (log file is located at /srv/oe/build/tmp-lkft-glibc/work/dragonboard_410c-linaro-linux/linux-generic-next/5.10+gitAUTOINC+8d374d0d44-r0/temp/log.do_deploy.10113)
17:46:52 NOTE: recipe linux-generic-next-5.10+gitAUTOINC+8d374d0d44-r0: task do_deploy: Failed
17:46:52 ERROR: Task (/srv/oe/build/conf/../../layers/meta-lkft/recipes-kernel/linux/linux-generic-next_git.bb:do_deploy) failed with exit code '1'

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>