### PR TITLE
kselftests (in-kernel): Remove libcap-ng dependency

### DIFF
--- a/recipes-kernel/linux/kselftests.inc
+++ b/recipes-kernel/linux/kselftests.inc
@@ -1,7 +1,7 @@
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # kernel selftests dependencies
-DEPENDS += "elfutils fuse libcap libcap-ng pkgconfig-native popt rsync-native util-linux clang-native \
+DEPENDS += "elfutils fuse libcap pkgconfig-native popt rsync-native util-linux clang-native \
     ${@bb.utils.contains("TARGET_ARCH", "arm", "", "numactl", d)} \
 "
 


### PR DESCRIPTION
Since `v5.11-rc4-6-g2cea4a7a1885` ("scripts: use pkg-config to locate libcrypto"), building the kernel + kselftests has failed for x86_64.

After a long, exhaustive investigation, the culprit behind this breakage turned out to be the unsuspecting butler^W `libcap-ng` when added as a dependency to the recipe. Reasons for this are still unclear, but adding it into the mix spoils the sysroot environment so that linking fails against libc and others. It's a twisted plot because some parts of kselftests (or the kernel, rather) need to be compiled natively while others need to be cross-compiled. This is the error message:

```
/oe/build/tmp/hosttools/ld: cannot find /lib/libc.so.6
/oe/build/tmp/hosttools/ld: cannot find /usr/lib/libc_nonshared.a
/oe/build/tmp/hosttools/ld: cannot find /lib/ld-linux-x86-64.so.2
collect2: error: ld returned 1 exit status
scripts/Makefile.host:95: recipe for target 'scripts/extract-cert' failed
make[2]: *** [scripts/extract-cert] Error 1
```

By removing `libcap-ng` as a dependency we lose the capabilities selftests (`test_execve` and `validate_cap`).