### PR TITLE
linux: lkft.config: enable CONFIG_KFENCE

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -160,3 +160,7 @@ CONFIG_DYNAMIC_DEBUG=y
 # Multipath TCP
 # https://lore.kernel.org/netdev/20190617225808.665-1-mathew.j.martineau@linux.intel.com/
 CONFIG_MPTCP=y
+
+# Enable debug option
+# https://projects.linaro.org/browse/LKQ-186
+CONFIG_KFENCE=y


### PR DESCRIPTION
Kernel Electric-Fence (KFENCE) is a low-overhead sampling-based memory
safety error detector. KFENCE detects heap out-of-bounds access,
use-after-free, and invalid-free errors.

KFENCE is designed to be enabled in production kernels, and has near
zero performance overhead. Compared to KASAN, KFENCE trades performance
for precision. The main motivation behind KFENCE's design, is that with
enough total uptime KFENCE will detect bugs in code paths not
typically exercised by non-production test workloads. One way to
quickly achieve a large enough total uptime is when the tool is
deployed across a large fleet of machines.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>