### PR TITLE
packagegroup: Add perf-tests

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -20,6 +20,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     net-snmp \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     perf \
+    perf-tests \
     qemu \
     tzdata \
     xz \


### PR DESCRIPTION
Some tests are shipped with Perf but on its own package, `perf-tests`. These tests are autodetected by Perf at run-time so this will enable many tests that had not been shipped before.