### PR TITLE
perf: Add bash as run-time dependency

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -6,3 +6,4 @@ PERF_SRC += "scripts"
 
 RDEPENDS_${PN} += "libcap"
 RDEPENDS_${PN}-python += "libcap"
+RDEPENDS_${PN}-tests += "bash"


### PR DESCRIPTION
As of 2021-03-28, `perf-tests` require Bash as a run-time dependency. This was introduced by merge-commit `f9e2bb42cf0d`, very likely coming from commit `1dc481c0b0cf1` ("perf test: Change to use bash for daemon test"), which changes `tools/perf/tests/shell/daemon.sh`.