### PR TITLE
packagegroup: Don't build Packetdrill on 32-bits machines

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -19,7 +19,7 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     libgpiod \
     net-snmp \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
-    packetdrill \
+    ${@bb.utils.contains_any("TUNE_ARCH", "arm i686", "", "packetdrill", d)} \
     perf \
     perf-tests \
     qemu \


### PR DESCRIPTION
The current source code of Packetdrill does not compile on 32-bits architectures because some data type mismatch. For example:
```
run_system_call.c: In function 'cmsg_expect_eq':
run_system_call.c:860:38: error: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'size_t {aka unsigned int}' [-Werror=format=]
      "Bad len in cmsg %d: expected=%lu actual=%lu",
                                    ~~^
                                    %u
      i, ecm->cmsg_len, acm->cmsg_len);
```

Another example:
```
run_system_call.c: In function 'get_epoll_event_from_expr':
run_system_call.c:2924:21: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   event->data.ptr = (void *)epollev_expr->ptr->value.num;
                     ^
```