### PR TITLE
kselftests-next: Refresh lib.mk patch

### DIFF
--- a/recipes-overlayed/kselftests/files/0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.12.patch
+++ b/recipes-overlayed/kselftests/files/0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.12.patch
@@ -1,22 +1,29 @@
-From 2e93b68257aa88ccdc127ca119304a5f4c76b7c5 Mon Sep 17 00:00:00 2001
+From 560ea493e7d2c010422073c59d0501f440798120 Mon Sep 17 00:00:00 2001
 From: Fathi Boudra <fathi.boudra@linaro.org>
 Date: Wed, 22 Mar 2017 17:36:53 +0200
-Subject: [PATCH] selftests: lib: allow to override CC in the top-level Makefile
+Subject: [PATCH] selftests: lib: allow to override CC in the top-level
+ Makefile
 
 Relax CC assignment to allow to override CC in the top-level Makefile.
 
 Signed-off-by: Denys Dmytriyenko <denys@ti.com>
 ---
- tools/testing/selftests/lib.mk |    2 +-
+ tools/testing/selftests/lib.mk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
+diff --git a/tools/testing/selftests/lib.mk b/tools/testing/selftests/lib.mk
+index 0af84ad48aa7..b473ebf8a0a6 100644
 --- a/tools/testing/selftests/lib.mk
 +++ b/tools/testing/selftests/lib.mk
-@@ -1,6 +1,6 @@
- # This mimics the top-level Makefile. We do it explicitly here so that this
- # Makefile can operate with or without the kbuild infrastructure.
+@@ -3,7 +3,7 @@
+ ifneq ($(LLVM),)
+ CC := clang
+ else
 -CC := $(CROSS_COMPILE)gcc
 +CC ?= $(CROSS_COMPILE)gcc
+ endif
  
  ifeq (0,$(MAKELEVEL))
- OUTPUT := $(shell pwd)
+-- 
+2.25.1
+

--- a/recipes-overlayed/kselftests/kselftests-next_git.bb
+++ b/recipes-overlayed/kselftests/kselftests-next_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git;pro
 # Patches inappropriate or not yet merged by upstream
 # Some patches may have been submitted to upstream
 SRC_URI += "\
-    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile.patch \
+    file://0001-selftests-lib-allow-to-override-CC-in-the-top-level-Makefile-v5.12.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Since commit `26e6dd107276` (`selftests: Set CC to clang in lib.mk if LLVM is set`) was merged into linux-next 2021-04-16, the patch that allows `CC` to be overridden does not apply. This refreshes that patch.