### PR TITLE
linux: Remove sm8350 and sc7280 from deploy on 5.12-rc

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable-rc_5.12.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.12.bb
@@ -109,7 +109,7 @@ do_deploy_append() {
     # |   File "/usr/bin/skales/dtbTool", line 239, in __init__
     # |     self.msm_id[0] = soc_ids[matches['soc']] | (foundry << 16)
     # | KeyError: u'ipq8074'
-    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* ) || true
+    ( cd ${B}/arch/arm64/boot/dts/qcom/ && rm -vf *ipq8074* *qcs404* *sdm845* *sm8150* *sc7180* *ipq6018* *sm8250* *qrb5165* *sm8350* *sc7280* ) || true
 }
 
 require machine-specific-hooks.inc


### PR DESCRIPTION
A pair of Qualcomm boards were added in the 5.12-rc process, which were incorporated into our mainline and next recipes in due time (1faaac694bd8 and 8efbb4e3de7b). This was missed when the recipe for v5.12.y was created, so this fixes it.