### PR TITLE
packagegroups: rpb-lkft: add sanitizer

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -17,6 +17,8 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-mainline \
     kselftests-next \
     libgpiod \
+    libsan \
+    libubsan \
     net-snmp \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     ${@bb.utils.contains_any("TUNE_ARCH", "arm i686", "", "packetdrill", d)} \


### PR DESCRIPTION
When trying to run kselftest built from tuxsuite the following issue
shows up:

\# selftests: openat2: openat2_test
\# /usr/bin/timeout: failed to run command './openat2_test': No such file
or directory
not ok 1 selftests: openat2: openat2_test # exit=127

That's due to the sanitizer isn't installed.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>