### PR TITLE
packagegroup: Add cpupower, libgpiod-tools, libhugetlbfs, s-suite

### DIFF
--- a/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
+++ b/recipes-samples/packagegroups/packagegroup-rpb-lkft.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 # contains basic dependencies for LKFT
 RDEPENDS_packagegroup-rpb-lkft = "\
     android-kernel-tests \
+    cpupower \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "fwts", d)} \
     git \
     grep \
@@ -17,12 +18,15 @@ RDEPENDS_packagegroup-rpb-lkft = "\
     kselftests-mainline \
     kselftests-next \
     libgpiod \
+    libgpiod-tools \
+    libhugetlbfs-tests \
     net-snmp \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     ${@bb.utils.contains_any("TUNE_ARCH", "arm i686", "", "packetdrill", d)} \
     perf \
     perf-tests \
     qemu \
+    s-suite \
     tzdata \
     xz \
     "


### PR DESCRIPTION
These packages have been included in our root file system because they are a part of the packagegroup-rpb-tests. We want more control over it, like not adding libhugetlbfs when building for architectures on which it's not supported.