### PR TITLE
recipe-kernel: linux-lkft.inc: add DEPENDS libyaml

### DIFF
--- a/recipes-kernel/linux/linux-lkft.inc
+++ b/recipes-kernel/linux/linux-lkft.inc
@@ -228,6 +228,9 @@ RRECOMMENDS_${KERNEL_PACKAGE_NAME}-image_append = " ${KERNEL_PACKAGE_NAME}-devic
 DEPENDS += "openssl-native"
 export HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
 
+# Makefile:23: *** dtc needs libyaml for DT
+DEPENDS += "libyaml"
+
 # Automatically depend on lzop/lz4-native if CONFIG_KERNEL_LZO/LZ4 is enabled
 python () {
     try:


### PR DESCRIPTION
When building next from tag next-20210914 we see the following error.

09:00:29 | /srv/oe/build/tmp-lkft-glibc/work-shared/juno/kernel-source/scripts/dtc/Makefile:23: *** dtc needs libyaml for DT schema validation support. Install the necessary libyaml development package..  Stop.
09:00:29 | make: *** [/srv/oe/build/tmp-lkft-glibc/work-shared/juno/kernel-source/Makefile:1541: scripts_dtc] Error 2
09:00:29 | ERROR: oe_runmake failed
09:00:29 | WARNING: exit code 1 from a shell command.
09:00:29 | ERROR: Function failed: do_compile (log file is located at /srv/oe/build/tmp-lkft-glibc/work/juno-linaro-linux/linux-generic-next/5.14+gitAUTOINC+815c5020b5-r0/temp/log.do_compile.12621)
09:00:29 NOTE: recipe linux-generic-next-5.14+gitAUTOINC+815c5020b5-r0: task do_compile: Failed
09:00:29 ERROR: Task (/srv/oe/build/conf/../../layers/meta-lkft/recipes-kernel/linux/linux-generic-next_git.bb:do_compile) failed with exit code '1'
09:00:29 NOTE: Tasks Summary: Attempted 5766 tasks of which 4730 didn't need to be rerun and 1 failed.
09:00:31 NOTE: Build completion summary:
09:00:31 NOTE:   do_populate_sysroot: 99.7% sstate reuse(389 setscene, 1 scratch)
09:00:31 NOTE:   do_package_qa: 99.6% sstate reuse(281 setscene, 1 scratch)
09:00:31 NOTE:   do_package: 50.0% sstate reuse(1 setscene, 1 scratch)
09:00:31 NOTE:   do_packagedata: 99.6% sstate reuse(282 setscene, 1 scratch)
09:00:31 NOTE:   do_package_write_ipk: 99.6% sstate reuse(281 setscene, 1 scratch)
09:00:31 NOTE:   do_populate_lic: 99.0% sstate reuse(398 setscene, 4 scratch)
09:00:31 NOTE: Writing buildhistory

Add a build dependency on 'libyaml'.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>