### PR TITLE
ltp: Upgrade to 20210927

### DIFF
--- a/recipes-extended/ltp/ltp/0001-Remove-OOM-tests-from-runtest-mm.patch
+++ b/recipes-extended/ltp/ltp/0001-Remove-OOM-tests-from-runtest-mm.patch
@@ -1,0 +1,35 @@
+From e87c2ad1e16cdbd62ba71b2ace3270503decaa56 Mon Sep 17 00:00:00 2001
+From: "Mingde (Matthew) Zeng" <matthewzmd@gmail.com>
+Date: Wed, 29 Jul 2020 08:47:09 -0400
+Subject: [PATCH] Remove OOM tests from runtest/mm
+
+Disable OOM tests, as they might cause oeqa ssh connection lost
+
+Upstream-Status: Inappropriate [oe-core specific]
+Signed-off-by: Mingde (Matthew) Zeng <matthew.zeng@windriver.com>
+[ pvorel: rebased for 20210927 ]
+Signed-off-by: Petr Vorel <petr.vorel@gmail.com>
+---
+ runtest/mm | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/runtest/mm b/runtest/mm
+index 6537666a9..e5a091a5a 100644
+--- a/runtest/mm
++++ b/runtest/mm
+@@ -73,12 +73,6 @@ ksm06_2 ksm06 -n 8000
+ 
+ cpuset01 cpuset01
+ 
+-oom01 oom01
+-oom02 oom02
+-oom03 oom03
+-oom04 oom04
+-oom05 oom05
+-
+ swapping01 swapping01 -i 5
+ 
+ thp01 thp01 -I 120
+-- 
+2.33.0
+

--- a/recipes-extended/ltp/ltp/0002-lib-fix-MemAvailable-parsing.patch
+++ b/recipes-extended/ltp/ltp/0002-lib-fix-MemAvailable-parsing.patch
@@ -1,0 +1,36 @@
+From 29a096fe2bd356f419bd8a8404d5b652c996b92f Mon Sep 17 00:00:00 2001
+From: Ralph Siemsen <ralph.siemsen@linaro.org>
+Date: Mon, 27 Sep 2021 22:18:50 -0400
+Subject: [PATCH] lib: fix MemAvailable parsing
+
+The amount of available memory was not being returned correctly, which
+resulted in tests being executed when they should have been skipped.
+
+Fixes: 8759f4 ("lib: adjust the tmpfs size according to .dev_min_size and MemAvailable")
+Signed-off-by: Ralph Siemsen <ralph.siemsen@linaro.org>
+Signed-off-by: Li Wang <liwang@redhat.com>
+Signed-off-by: Petr Vorel <petr.vorel@gmail.com>
+[ upstream status: e42149e28 ("lib: fix MemAvailable parsing") ]
+---
+ lib/tst_memutils.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/tst_memutils.c b/lib/tst_memutils.c
+index ae1cad29b..a46de78f5 100644
+--- a/lib/tst_memutils.c
++++ b/lib/tst_memutils.c
+@@ -65,9 +65,9 @@ void tst_pollute_memory(size_t maxsize, int fillchar)
+ 
+ long long tst_available_mem(void)
+ {
+-	long long mem_available;
++	unsigned long long mem_available = 0;
+ 
+-	if (FILE_LINES_SCANF("/proc/meminfo", "MemAvailable: %ld",
++	if (FILE_LINES_SCANF("/proc/meminfo", "MemAvailable: %llu",
+ 		&mem_available)) {
+ 		mem_available = SAFE_READ_MEMINFO("MemFree:")
+ 			+ SAFE_READ_MEMINFO("Cached:");
+-- 
+2.33.0
+

--- a/recipes-extended/ltp/ltp/0003-lapi-rtnetlink.h-Fix-include-guards.patch
+++ b/recipes-extended/ltp/ltp/0003-lapi-rtnetlink.h-Fix-include-guards.patch
@@ -1,0 +1,37 @@
+From 881709d1e4d1bba5bf8ca365bc058f338bd72dc2 Mon Sep 17 00:00:00 2001
+From: Petr Vorel <petr.vorel@gmail.com>
+Date: Wed, 29 Sep 2021 19:38:42 +0200
+Subject: [PATCH] lapi/rtnetlink.h: Fix include guards
+
+Fixes: 5fea0638a ("lapi: Add missing IFA_FLAGS")
+
+Signed-off-by: Petr Vorel <petr.vorel@gmail.com>
+[ upstream status: a2a212cf8 ("lapi/rtnetlink.h: Fix include guards") ]
+---
+ include/lapi/rtnetlink.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/lapi/rtnetlink.h b/include/lapi/rtnetlink.h
+index 8a1b5385b..04e9ad51a 100644
+--- a/include/lapi/rtnetlink.h
++++ b/include/lapi/rtnetlink.h
+@@ -1,8 +1,8 @@
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ /* Copyright (c) 2021 Petr Vorel <petr.vorel@gmail.com> */
+
+-#ifndef LAPI_IF_ADDR_H__
+-# define LAPI_IF_ADDR_H__
++#ifndef LAPI_RTNETLINK_H__
++# define LAPI_RTNETLINK_H__
+
+ #include <linux/rtnetlink.h>
+
+@@ -10,4 +10,4 @@
+ # define IFA_FLAGS 8
+ #endif
+
+-#endif	/* LAPI_IF_ADDR_H__ */
++#endif	/* LAPI_RTNETLINK_H__ */
+--
+2.33.0
+

--- a/recipes-extended/ltp/ltp/0004-lapi-Create-if_addr.h-and-reuse-it-in-rtnetlink.h.patch
+++ b/recipes-extended/ltp/ltp/0004-lapi-Create-if_addr.h-and-reuse-it-in-rtnetlink.h.patch
@@ -1,0 +1,58 @@
+From b13440627bd4a9f060a33d400a47a40daa2bc12e Mon Sep 17 00:00:00 2001
+From: Petr Vorel <petr.vorel@gmail.com>
+Date: Wed, 29 Sep 2021 19:37:19 +0200
+Subject: [PATCH] lapi: Create if_addr.h and reuse it in rtnetlink.h
+
+There will be fix in next commit for missing IFA_F_NOPREFIXROUTE which
+requires creating lapi/if_addr.h. Thus move IFA_FLAGS to lapi/if_addr.h,
+as it belongs there and reuse lapi/if_addr.h in lapi/rtnetlink.h just
+like <linux/rtnetlink.h> includes <linux/if_addr.h>.
+
+Signed-off-by: Petr Vorel <petr.vorel@gmail.com>
+[ upstream status: https://lore.kernel.org/ltp/20210930183058.5240-3-petr.vorel@gmail.com/T/#u ]
+---
+ include/lapi/if_addr.h   | 16 ++++++++++++++++
+ include/lapi/rtnetlink.h |  5 +----
+ 2 files changed, 17 insertions(+), 4 deletions(-)
+ create mode 100644 include/lapi/if_addr.h
+
+diff --git a/include/lapi/if_addr.h b/include/lapi/if_addr.h
+new file mode 100644
+index 000000000..4e50a0a4e
+--- /dev/null
++++ b/include/lapi/if_addr.h
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Copyright (c) 2021 Petr Vorel <petr.vorel@gmail.com>
++ */
++
++#ifndef LAPI_IF_ADDR_H__
++#define LAPI_IF_ADDR_H__
++
++#include <linux/if_addr.h>
++
++#ifndef IFA_FLAGS
++# define IFA_FLAGS 8
++#endif
++
++
++#endif /* LAPI_IF_ADDR_H__ */
+diff --git a/include/lapi/rtnetlink.h b/include/lapi/rtnetlink.h
+index 04e9ad51a..089bf1a0d 100644
+--- a/include/lapi/rtnetlink.h
++++ b/include/lapi/rtnetlink.h
+@@ -5,9 +5,6 @@
+ # define LAPI_RTNETLINK_H__
+
+ #include <linux/rtnetlink.h>
+-
+-#ifndef IFA_FLAGS
+-# define IFA_FLAGS 8
+-#endif
++#include "lapi/if_addr.h"
+
+ #endif	/* LAPI_RTNETLINK_H__ */
+--
+2.33.0
+

--- a/recipes-extended/ltp/ltp/0005-lapi-if_addr.h-Define-IFA_FLAGS.patch
+++ b/recipes-extended/ltp/ltp/0005-lapi-if_addr.h-Define-IFA_FLAGS.patch
@@ -1,0 +1,60 @@
+From 9e357fb4fc00ab9c303e314b85b9ae3836141f81 Mon Sep 17 00:00:00 2001
+From: Petr Vorel <petr.vorel@gmail.com>
+Date: Wed, 29 Sep 2021 19:56:29 +0200
+Subject: [PATCH] lapi/if_addr.h: Define IFA_FLAGS
+
+and use it in icmp_rate_limit01.c.
+
+This fixes error on toolchains with very old kernel headers, e.g.
+Buildroot sourcery-arm:
+
+icmp_rate_limit01.c:82:3: error: 'IFA_F_NOPREFIXROUTE' undeclared (first use in this function)
+   IFA_F_NOPREFIXROUTE);
+
+Fixed because IFA_F_NOPREFIXROUTE was added in 3.14 and the oldest
+system we still support is Cent0S 7 with 3.10 kernel.
+
+NOTE: Cent0S 7 is obviously heavily patched thus it contains
+IFA_F_NOPREFIXROUTE and therefore CI build didn't catch this error.
+
+Signed-off-by: Petr Vorel <petr.vorel@gmail.com>
+[ upstream status: https://lore.kernel.org/ltp/20210930183058.5240-4-petr.vorel@gmail.com/T/#u ]
+---
+ include/lapi/if_addr.h            | 3 +++
+ testcases/cve/icmp_rate_limit01.c | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/lapi/if_addr.h b/include/lapi/if_addr.h
+index 4e50a0a4e..0f7e44784 100644
+--- a/include/lapi/if_addr.h
++++ b/include/lapi/if_addr.h
+@@ -12,5 +12,8 @@
+ # define IFA_FLAGS 8
+ #endif
+
++#ifndef IFA_F_NOPREFIXROUTE
++# define IFA_F_NOPREFIXROUTE	0x200
++#endif
+
+ #endif /* LAPI_IF_ADDR_H__ */
+diff --git a/testcases/cve/icmp_rate_limit01.c b/testcases/cve/icmp_rate_limit01.c
+index b3a237b30..3ada32675 100644
+--- a/testcases/cve/icmp_rate_limit01.c
++++ b/testcases/cve/icmp_rate_limit01.c
+@@ -27,11 +27,12 @@
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>
+-#include <linux/if_addr.h>
+ #include <linux/errqueue.h>
+
+ #include <sched.h>
+ #include <limits.h>
++
++#include "lapi/if_addr.h"
+ #include "tst_test.h"
+ #include "tst_netdevice.h"
+
+--
+2.33.0
+

--- a/recipes-extended/ltp/ltp_20210927.bb
+++ b/recipes-extended/ltp/ltp_20210927.bb
@@ -5,13 +5,8 @@ SECTION = "console/utils"
 LICENSE = "GPLv2 & GPLv2+ & LGPLv2+ & LGPLv2.1+ & BSD-2-Clause"
 LIC_FILES_CHKSUM = "\
     file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
-    file://testcases/kernel/controllers/freezer/COPYING;md5=0636e73ff0215e8d672dc4c32c317bb3 \
-    file://testcases/kernel/controllers/freezer/run_freezer.sh;beginline=5;endline=17;md5=86a61d2c042d59836ffb353a21456498 \
-    file://testcases/kernel/hotplug/memory_hotplug/COPYING;md5=e04a2e542b2b8629bf9cd2ba29b0fe41 \
-    file://testcases/kernel/hotplug/cpu_hotplug/COPYING;md5=e04a2e542b2b8629bf9cd2ba29b0fe41 \
     file://testcases/open_posix_testsuite/COPYING;md5=48b1c5ec633e3e30ec2cf884ae699947 \
-    file://testcases/realtime/COPYING;md5=12f884d2ae1ff87c09e5b7ccc2c4ca7e \
-    file://utils/benchmark/kernbench-0.42/COPYING;md5=94d55d512a9ba36caa9b7df079bae19f \
+    file://testcases/network/can/filter-tests/COPYING;md5=5b155ea7d7f86eae8e8832955d8b70bc \
 "
 
 DEPENDS = "attr libaio libcap acl openssl zip-native"
@@ -27,13 +22,15 @@ CFLAGS_append_x86-64 = " -fomit-frame-pointer"
 
 CFLAGS_append_powerpc64 = " -D__SANE_USERSPACE_TYPES__"
 CFLAGS_append_mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
-SRCREV = "0fb171f2beddaf64bd27597577c206c0f892b3cd"
+SRCREV = "12beeda351b5d758a729aaf695b836ccc9eb5304"
 
-# reset at next version upgrade or when output changes
-PR = "r0"
-HASHEQUIV_HASH_VERSION .= ".0"
-
-SRC_URI = "git://github.com/linux-test-project/ltp.git"
+SRC_URI = "git://github.com/linux-test-project/ltp.git \
+           file://0001-Remove-OOM-tests-from-runtest-mm.patch \
+           file://0002-lib-fix-MemAvailable-parsing.patch \
+           file://0003-lapi-rtnetlink.h-Fix-include-guards.patch \
+           file://0004-lapi-Create-if_addr.h-and-reuse-it-in-rtnetlink.h.patch \
+           file://0005-lapi-if_addr.h-Define-IFA_FLAGS.patch \
+           "
 
 S = "${WORKDIR}/git"
 
@@ -120,9 +117,8 @@ remove_broken_musl_sources() {
 	echo "WARNING: remove unsupported tests (until they're fixed)"
 
 	# sync with upstream
-	# https://github.com/linux-test-project/ltp/blob/master/travis/alpine.sh#L33
+	# https://github.com/linux-test-project/ltp/blob/master/ci/alpine.sh#L33
 	rm -rfv \
-		testcases/kernel/sched/process_stress/process.c \
 		testcases/kernel/syscalls/confstr/confstr01.c \
 		testcases/kernel/syscalls/fmtmsg/fmtmsg01.c \
 		testcases/kernel/syscalls/getcontext/getcontext01.c \


### PR DESCRIPTION
This is the patch posted by Petr Vorel to the oe-core mailing list, with:
* override separators changed to Sumo,
* update to LICENSE checks.