### PR TITLE
linux: Disable GCC plug-ins in LKFT config fragment

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -41,6 +41,9 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # Disable ARM 32-bits plug-ins for GCC 9-
+        echo 'CONFIG_GCC_PLUGINS=n' >> ${B}/.config
+        echo 'CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=n' >> ${B}/.config
       ;;
       mips)
         cp ${S}/arch/mips/configs/malta_qemu_32r6_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -41,6 +41,9 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # Disable ARM 32-bits plug-ins for GCC 9-
+        echo 'CONFIG_GCC_PLUGINS=n' >> ${B}/.config
+        echo 'CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=n' >> ${B}/.config
       ;;
       mips)
         cp ${S}/arch/mips/configs/malta_qemu_32r6_defconfig ${B}/.config

--- a/recipes-kernel/linux/linux-generic-stable-rc_5.14.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.14.bb
@@ -41,6 +41,9 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # Disable ARM 32-bits plug-ins for GCC 9-
+        echo 'CONFIG_GCC_PLUGINS=n' >> ${B}/.config
+        echo 'CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=n' >> ${B}/.config
       ;;
       mips)
         cp ${S}/arch/mips/configs/malta_qemu_32r6_defconfig ${B}/.config


### PR DESCRIPTION
The configuration set to yes has led to the kernel failing to build on (oddly enough) newer systems:
```
| In file included from /poky/build/tmp-lkft-glibc/work/am57xx_evm-linaro-linux-gnueabi/linux-generic-mainline/5.14+gitAUTOINC+7d2a07b769-r0/recipe-sysroot-native/usr/bin/arm-linaro-linux-gnueabi/../../lib/arm-linaro-linux-gnueabi/gcc/arm-linaro-linux-gnueabi/7.3.0/plugin/include/gcc-plugin.h:28,
|                  from /poky/build/tmp-lkft-glibc/work-shared/am57xx-evm/kernel-source/scripts/gcc-plugins/gcc-common.h:7,
|                  from /poky/build/tmp-lkft-glibc/work-shared/am57xx-evm/kernel-source/scripts/gcc-plugins/arm_ssp_per_task_plugin.c:3:
| /poky/build/tmp-lkft-glibc/work/am57xx_evm-linaro-linux-gnueabi/linux-generic-mainline/5.14+gitAUTOINC+7d2a07b769-r0/recipe-sysroot-native/usr/bin/arm-linaro-linux-gnueabi/../../lib/arm-linaro-linux-gnueabi/gcc/arm-linaro-linux-gnueabi/7.3.0/plugin/include/system.h:691:10: fatal error: libiberty.h: No such file or directory
|  #include "libiberty.h"
|           ^~~~~~~~~~~~~
| compilation terminated.
| make[3]: *** [/poky/build/tmp-lkft-glibc/work-shared/am57xx-evm/kernel-source/scripts/gcc-plugins/Makefile:48: scripts/gcc-plugins/arm_ssp_per_task_plugin.so] Error 1
| make[2]: *** [/poky/build/tmp-lkft-glibc/work-shared/am57xx-evm/kernel-source/scripts/Makefile.build:514: scripts/gcc-plugins] Error 2
```

This can be reproduced under Docker, and currently affects our Jenkins and Gitlab builds, which run on clean environments under Docker (two different images and base distros).

On an older system, Hackbox, with uncontrolled sources installed on the host's root file system, this is not a problem at all, as the two configs do not get selected.

This kernel configuration works:
```
CONFIG_HAVE_GCC_PLUGINS=y
```
whereas this set of configs fail:
```
CONFIG_HAVE_GCC_PLUGINS=y
CONFIG_GCC_PLUGINS=y
# CONFIG_GCC_PLUGIN_CYC_COMPLEXITY is not set
# CONFIG_GCC_PLUGIN_LATENT_ENTROPY is not set
# CONFIG_GCC_PLUGIN_RANDSTRUCT is not set
CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=y
```