### PR TITLE
linux: lkft.config: enable libgipod

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -187,3 +187,8 @@ CONFIG_ARM_SCMI_CPUFREQ=y
 # Needed fragments for mmtests
 # sysbenchcpu
 CONFIG_SCHEDSTATS=y
+
+# libgpiod
+CONFIG_GPIOLIB=y
+CONFIG_GPIO_CDEV=y
+CONFIG_CPIO_MOCKUP=m


### PR DESCRIPTION
When running libgpiod tests the following warning shows up:

[32m[INFO]  [0mchecking the linux kernel version
[32m[INFO]  [0mkernel release is v5.15.0 - ok to run tests
[32m[INFO]  [0musing gpio-tools from '/usr/bin'
[31m[FATAL] [0merror checking the availability of gpio-mockup: No such file or directory
[32m[INFO]  [0mcleaning up

Enable needed fragments.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>