### PR TITLE
linux: mainline/next: Work around DT validation

### DIFF
--- a/recipes-kernel/linux/linux-generic-mainline_git.bb
+++ b/recipes-kernel/linux/linux-generic-mainline_git.bb
@@ -105,6 +105,13 @@ do_configure() {
     oe_runmake -C ${B} savedefconfig
 }
 
+do_compile_prepend() {
+    sed -i \
+        -e 's#^%.dtb: dt_binding_check #%.dtb: #' \
+        -e 's# \$(dtstree)/\$\*.dt.yaml$##' \
+        ${S}/Makefile
+}
+
 do_deploy_append() {
     cp -a ${B}/defconfig ${DEPLOYDIR}
     cp -a ${B}/.config ${DEPLOYDIR}/config

--- a/recipes-kernel/linux/linux-generic-next_git.bb
+++ b/recipes-kernel/linux/linux-generic-next_git.bb
@@ -105,6 +105,13 @@ do_configure() {
     oe_runmake -C ${B} savedefconfig
 }
 
+do_compile_prepend() {
+    sed -i \
+        -e 's#^%.dtb: dt_binding_check #%.dtb: #' \
+        -e 's# \$(dtstree)/\$\*.dt.yaml$##' \
+        ${S}/Makefile
+}
+
 do_deploy_append() {
     cp -a ${B}/defconfig ${DEPLOYDIR}
     cp -a ${B}/.config ${DEPLOYDIR}/config


### PR DESCRIPTION
Since patch 53182e81f47d ("kbuild: Enable DT schema checks for %.dtb targets") [1] made it into the kernel (first on next, then on mainline), we've been seeing issues building the kernel on machines that require building a DTB:
```
NOTE: make -j 8 -j 8 arm/juno.dtb
  SYNC    include/config/auto.conf.cmd
  GEN     Makefile
Error: 'dt-doc-validate' not found!
Ensure dtschema python package is installed and in your PATH.
```
And while the `dtschema` package can be installed into the native staging directory, problem persists as the `python3` binary used while building the kernel is still the one from the host, not the one built as `python3-native`.

Even with `dtschema` installed in both the host and the native environment, the `dt-doc-validate` binary fails to launch due to failed Python import. (Furthermore, some of the dependencies pulled in by the whole process are too new for the native Python 3.5 that we have at hand.)

This abomination of a workaround allows us to at least get the kernel building again while we figure out a good solution to the problem.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=53182e81f47d4ea0c727c49ad23cb782173ab849