### PR TITLE
linux: Disable VDSO kconfigs

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -187,3 +187,7 @@ CONFIG_ARM_SCMI_CPUFREQ=y
 # Needed fragments for mmtests
 # sysbenchcpu
 CONFIG_SCHEDSTATS=y
+
+# Disable VDSO settings
+CONFIG_GENERIC_COMPAT_VDSO=n
+CONFIG_COMPAT_VDSO=n


### PR DESCRIPTION
A recent change in Tuxmake (setting `CROSS_COMPILE_COMPAT`) means that the 5.4 kernel now fails when building for Arm64, since it sets these two configs to yes:
```
CONFIG_GENERIC_COMPAT_VDSO
CONFIG_COMPAT_VDSO
```
Setting this to no reverts to the old behavior.