### PR TITLE
Revert "linux: Disable VDSO kconfigs"

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -187,7 +187,3 @@ CONFIG_ARM_SCMI_CPUFREQ=y
 # Needed fragments for mmtests
 # sysbenchcpu
 CONFIG_SCHEDSTATS=y
-
-# Disable VDSO settings
-CONFIG_GENERIC_COMPAT_VDSO=n
-CONFIG_COMPAT_VDSO=n


### PR DESCRIPTION
This reverts commit 03c7a43ff2cbee4be68b4f71cf289a82d99d787b.

We have split out the `tuxconfig.yml` in our pipelines, so now we are able to add this specific kernel configuration in the 5.4 Tuxconfig file. No need anymore to have this here, which had the side effect of affecting all branches, not just 5.4.