### PR TITLE
linux: Disable GCC plug-ins in 5.10 too

### DIFF
--- a/recipes-kernel/linux/linux-generic-stable-rc_5.10.bb
+++ b/recipes-kernel/linux/linux-generic-stable-rc_5.10.bb
@@ -41,6 +41,9 @@ do_configure() {
         echo 'CONFIG_ARM_TI_CPUFREQ=y' >> ${B}/.config
         echo 'CONFIG_SERIAL_8250_OMAP=y' >> ${B}/.config
         echo 'CONFIG_POSIX_MQUEUE=y' >> ${B}/.config
+        # Disable ARM 32-bits plug-ins for GCC 9-
+        echo 'CONFIG_GCC_PLUGINS=n' >> ${B}/.config
+        echo 'CONFIG_GCC_PLUGIN_ARM_SSP_PER_TASK=n' >> ${B}/.config
       ;;
       mips)
         cp ${S}/arch/mips/configs/malta_qemu_32r6_defconfig ${B}/.config


### PR DESCRIPTION
This has already been disabled in 5.14, 5.15, mainline and next, as per 85b14248936851068ffc53bdcbe44ec0444a41de.

The relevant patches have been backported to 5.10 now, so we need to disable the GCC plug-ins here too.