### PR TITLE
kernel: linux: files: lkft: enable BCMGENET=y

### DIFF
--- a/recipes-kernel/linux/files/lkft.config
+++ b/recipes-kernel/linux/files/lkft.config
@@ -187,3 +187,7 @@ CONFIG_ARM_SCMI_CPUFREQ=y
 # Needed fragments for mmtests
 # sysbenchcpu
 CONFIG_SCHEDSTATS=y
+
+# enable bcmgenet ethernet
+# rpi4 needs it to setup the NFS rootfs
+CONFIG_BCMGENET=y


### PR DESCRIPTION
Ethernet needs to be builtin in order to setup the NFS rootfs.

[  111.581228] VFS: Unable to mount root fs via NFS.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>