### PR TITLE
Swap libgpiod, cpupower in packagegroups, add new Tux console image

### DIFF
--- a/meta/recipes-samples/images/tux-lkft-console-image.bb
+++ b/meta/recipes-samples/images/tux-lkft-console-image.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Basic console image for LKFT"
+
+IMAGE_FEATURES += "debug-tweaks hwcodecs splash"
+
+# Add 1 GB of extra space on image.
+IMAGE_ROOTFS_EXTRA_SPACE = "1048576"
+
+# Add 512 MB on X15; more than that might exceed the
+# userdata partition capacity.
+IMAGE_ROOTFS_EXTRA_SPACE:am57xx-evm = "524288"
+
+LICENSE = "MIT"
+
+inherit core-image extrausers
+
+CORE_IMAGE_BASE_INSTALL += " \
+    kernel-modules \
+    libgpiod \
+    libgpiod-tools \
+    ltp \
+    packagegroup-lkft-tools-python3 \
+    "
+
+EXTRA_USERS_PARAMS = "\
+useradd -p '' linaro; \
+"

--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
@@ -13,6 +13,8 @@ RDEPENDS:packagegroup-lkft-testsuites = "\
     kernel-selftests \
     kselftests-mainline \
     kselftests-next \
+    libgpiod \
+    libgpiod-tools \
     ltp \
     perf-tests \
     s-suite \

--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -21,8 +21,6 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     grep \
     haveged \
     jq \
-    libgpiod \
-    libgpiod-tools \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     net-snmp \
     perf \

--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -17,7 +17,6 @@ RDEPENDS:packagegroup-lkft-tools = "\
 
 SUMMARY:packagegroup-lkft-tools = "Basic tools and libraries for LKFT"
 RDEPENDS:packagegroup-lkft-tools-basics = "\
-    cpupower \
     git \
     grep \
     haveged \


### PR DESCRIPTION
As far as I know cpupower is only used together with kselftest and x86
tests.
There for it should be dropped from here, since its already part of the
kselftests.inc package.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>