### PR TITLE
[kirkstone] linux: Add upstream status to patch needed for 4.15- kernels

### DIFF
--- a/meta/recipes-kernel/linux/files/0001-selftests-ftrace-add-more-config-fragments.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-ftrace-add-more-config-fragments.patch
@@ -11,6 +11,8 @@ http://pastebin.ubuntu.com/25784377/
 after the patch:
 http://pastebin.ubuntu.com/25784387/
 
+Upstream-Status: Backport
+
 Signed-off-by: Lei Yang <Lei.Yang@windriver.com>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>
 ---


### PR DESCRIPTION
This patch, `0001-selftests-ftrace-add-more-config-fragments.patch`, is used by:

* linux-generic-stable-rc_4.9.bb
* linux-generic-stable-rc_4.14.bb

and was missing its Upstream-Status of "backport". Imported initially from meta-96boards: https://github.com/96boards/meta-96boards/commit/d77cf38fe32ec962d36e1e9090442cdc5d941c5c