### PR TITLE
[kirkstone] linux: Add upstream status to patch needed for 4.9- kernels

### DIFF
--- a/meta/recipes-kernel/linux/files/0001-selftests-create-cpufreq-kconfig-fragments.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-create-cpufreq-kconfig-fragments.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] selftests: create cpufreq kconfig fragments
 For the better test coverage of cpufreq driver code these extra
 configurations are needed. Enable cpufreq governors and stats.
 
+Upstream-Status: Backport
+
 Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>
 Acked-by: Viresh Kumar <viresh.kumar@linaro.org>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>

--- a/meta/recipes-kernel/linux/files/0001-selftests-create-test-specific-kconfig-fragments.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-create-test-specific-kconfig-fragments.patch
@@ -17,6 +17,8 @@ Enable configs for all testcases:
 ./scripts/kconfig/merge_config.sh .config \
 		tools/testing/selftests/*/config
 
+Upstream-Status: Backport
+
 Signed-off-by: Bamvor Jian Zhang <bamvor.zhangjian@linaro.org>
 Reviewed-by: Shuah Khan <shuahkh@osg.samsung.com>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>

--- a/meta/recipes-kernel/linux/files/0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch
@@ -7,6 +7,8 @@ Subject: [PATCH] selftests: ftrace: add CONFIG_KPROBES=y to the config
 ftrace/kprobe tests require kprobes events. Enable kprobes to run these
 tests.
 
+Upstream-Status: Backport
+
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 Tested-by: Naresh Kamboju <naresh.kamboju@linaro.org>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>

--- a/meta/recipes-kernel/linux/files/0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch
@@ -9,6 +9,8 @@ CONFIG_GPIO_SYSFS is selected automatically by the gpio mockup driver.
 
 Tested on x86_64 and arm64 with defconfig and kselftest-merge.
 
+Upstream-Status: Backport
+
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>
 ---

--- a/meta/recipes-kernel/linux/files/0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch
@@ -7,6 +7,8 @@ Subject: [PATCH] selftests: lib: add config fragment for bitmap, printf and
 test_bitmap, test_printf and prime_numbers are expected to be built as
 modules.
 
+Upstream-Status: Backport
+
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 Tested-by: Naresh Kamboju <naresh.kamboju@linaro.org>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>

--- a/meta/recipes-kernel/linux/files/0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch
+++ b/meta/recipes-kernel/linux/files/0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] selftests: vm: add CONFIG_SYSVIPC=y to the config fragment
 vm tests rely on shared memory settings. Enable system V IPC to run these
 tests.
 
+Upstream-Status: Backport
+
 Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
 Tested-by: Naresh Kamboju <naresh.kamboju@linaro.org>
 Signed-off-by: Shuah Khan <shuahkh@osg.samsung.com>


### PR DESCRIPTION
These patches are needed by the 4.4 and 4.9 kernels:
```
0001-selftests-create-cpufreq-kconfig-fragments.patch [1]
0001-selftests-ftrace-add-CONFIG_KPROBES-y-to-the-config-.patch [1]
0001-selftests-ftrace-add-more-config-fragments.patch [2]
0001-selftests-lib-add-config-fragment-for-bitmap-printf-.patch [3]
0001-selftests-vm-add-CONFIG_SYSVIPC-y-to-the-config-frag.patch [1]
```
This patch is used by the 4.4 kernel:
```
0001-selftests-create-test-specific-kconfig-fragments.patch [1]
```
This patch is used by the 4.9 kernel:
```
0001-selftests-gpio-add-config-fragment-for-gpio-mockup.patch [1]
```
They all needed an Upstream-Status. The patches were introduced by the following commits in meta-96boards:
[1] https://github.com/96boards/meta-96boards/commit/270d06c7c532580b4e3c568215ed4eed144b0074
[2] https://github.com/96boards/meta-96boards/commit/d77cf38fe32ec962d36e1e9090442cdc5d941c5c
[3] https://github.com/96boards/meta-96boards/commit/c7e6bc8ac39bab14a5009d98478811fa6764455a