### PR TITLE
meta: samples: testsuites: drop mainline/next kselftest

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
@@ -11,8 +11,6 @@ RDEPENDS:packagegroup-lkft-testsuites = "\
       igt-gpu-tools-tests \
     ", d)} \
     kernel-selftests \
-    kselftests-mainline \
-    kselftests-next \
     libgpiod \
     libgpiod-tools \
     ltp \


### PR DESCRIPTION
No need to build kselftest-(mainline/next) since its never used. It only
take up space.

Suggested-by: Daniel Díaz <daniel.diaz@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>