### PR TITLE
meta: packagegroup: lkft-tools: add e2fsprogs*

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -17,6 +17,8 @@ RDEPENDS:packagegroup-lkft-tools = "\
 
 SUMMARY:packagegroup-lkft-tools = "Basic tools and libraries for LKFT"
 RDEPENDS:packagegroup-lkft-tools-basics = "\
+    e2fsprogs \
+    e2fsprogs-mke2fs \
     git \
     grep \
     haveged \


### PR DESCRIPTION
When booting up with kselftests rootfs the following happens:

/lava-5314279/0/tests/0_prep-inline/run.sh: line 15: mkfs: command not found

This is not happening when booting up the "normal" lkft rootfs nor the
"ltp" rootfs since ltp has an rdepend on these packages.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>