### PR TITLE
ltp: fix merge conflict

### DIFF
--- a/meta-lkft-testsuites/recipes-extended/ltp/ltp_20220527.bb
+++ b/meta-lkft-testsuites/recipes-extended/ltp/ltp_20220527.bb
@@ -23,7 +23,7 @@ CFLAGS:append:x86-64 = " -fomit-frame-pointer"
 
 CFLAGS:append:powerpc64 = " -D__SANE_USERSPACE_TYPES__"
 CFLAGS:append:mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
-SRCREV = "b0561ad8d9ee9fe1244b5385e941eb65a21e91a1"
+SRCREV = "6f88e0f6f1d6eb12c48c902f50f47ecbd3b0f18a"
 
 SRC_URI = "git://github.com/linux-test-project/ltp.git;protocol=https;branch=master"
 


### PR DESCRIPTION
When patch 8c303ceb96f8 ("ltp: Upgrade to 20220527") was cherry-picked
the merge resolution wasn't solved correctly. Fixing that.

Fixes: 8c303ceb96f8 ("ltp: Upgrade to 20220527")
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>