### PR TITLE
[sumo] Backport keyutils from meta-openembedded

### DIFF
--- a/recipes-security/keyutils/files/fix_library_install_path.patch
+++ b/recipes-security/keyutils/files/fix_library_install_path.patch
@@ -1,0 +1,28 @@
+From b0355cc205543ffd33752874295139d57c4fbc3e Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Tue, 26 Sep 2017 07:59:51 +0000
+Subject: [PATCH] Subject: [PATCH] keyutils: use relative path for link
+
+The absolute path of the symlink will be invalid
+when populated in sysroot, so use relative path instead.
+
+Upstream-Status: Pending
+
+Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+{rebased for 1.6]
+Signed-off-by: Armin Kuster <akuster808@gmail.com>
+
+Index: keyutils-1.6/Makefile
+===================================================================
+--- keyutils-1.6.orig/Makefile
++++ keyutils-1.6/Makefile
+@@ -184,7 +184,7 @@ ifeq ($(NO_SOLIB),0)
+ 	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
+ 	$(LNS) $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
+ 	mkdir -p $(DESTDIR)$(USRLIBDIR)
+-	$(LNS) $(LIBDIR)/$(SONAME) $(DESTDIR)$(USRLIBDIR)/$(DEVELLIB)
++	$(LNS) $(SONAME) $(DESTDIR)$(USRLIBDIR)/$(DEVELLIB)
+ 	sed \
+ 	-e 's,@VERSION\@,$(VERSION),g' \
+ 	-e 's,@prefix\@,$(PREFIX),g' \

--- a/recipes-security/keyutils/files/keyutils-fix-error-report-by-adding-default-message.patch
+++ b/recipes-security/keyutils/files/keyutils-fix-error-report-by-adding-default-message.patch
@@ -1,0 +1,42 @@
+fix keyutils test error report
+
+Upstream-Status: Pending
+
+"Permission denied" may be the reason of EKEYEXPIRED and EKEYREVOKED.
+"Required key not available" may be the reason of EKEYREVOKED.
+EXPIRED and REVOKED are 2 status of kernel security keys features.
+But the userspace keyutils lib will output the error message, which may
+have several reasons.
+
+Signed-off-by: Han Chao <chan@windriver.com>
+
+diff --git a/tests/toolbox.inc.sh b/tests/toolbox.inc.sh
+index bbca00a..739e9d0 100644
+--- a/tests/toolbox.inc.sh
++++ b/tests/toolbox.inc.sh
+@@ -227,11 +227,12 @@ function expect_error ()
+ 	    ;;
+ 	EKEYEXPIRED)
+ 	    my_err="Key has expired"
+-	    alt_err="Unknown error 127"
++	    alt_err="Permission denied"
+ 	    ;;
+ 	EKEYREVOKED)
+ 	    my_err="Key has been revoked"
+-	    alt_err="Unknown error 128"
++	    alt_err="Permission denied"
++	    alt2_err="Required key not available"
+ 	    ;;
+ 	EKEYREJECTED)
+ 	    my_err="Key has been rejected"
+@@ -249,6 +250,9 @@ function expect_error ()
+     elif [ "x$alt_err" != "x" ] && expr "$my_errmsg" : ".*: $alt_err" >&/dev/null
+     then
+ 	:
++    elif [ "x$alt2_err" != "x" ] && expr "$my_errmsg" : ".*: $alt2_err" >&/dev/null
++    then
++	:
+     elif [ "x$old_err" != "x" ] && expr "$my_errmsg" : ".*: $old_err" >&/dev/null
+     then
+ 	:
+

--- a/recipes-security/keyutils/files/keyutils-test-fix-output-format.patch
+++ b/recipes-security/keyutils/files/keyutils-test-fix-output-format.patch
@@ -1,0 +1,41 @@
+From 49b6321368e4bd3cd233d045cd09004ddd7968b2 Mon Sep 17 00:00:00 2001
+From: Jackie Huang <jackie.huang@windriver.com>
+Date: Mon, 15 May 2017 14:52:00 +0800
+Subject: [PATCH] keyutils: fix output format
+
+keyutils ptest output format is incorrect, according to yocto
+Development Manual
+(http://www.yoctoproject.org/docs/latest/dev-manual/dev-manual.html#testing-packages-with-ptest)
+5.10.6. Testing Packages With ptestThe test generates output in the format used by Automake:
+<result>: <testname>
+where the result can be PASS, FAIL, or SKIP, and the testname can be any
+identifying string.
+So we should change the test result format to match yocto ptest rules.
+
+Upstream-Status: Inappropriate [OE ptest specific]
+
+Signed-off-by: Li Wang <li.wang@windriver.com>
+Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+---
+ tests/runtest.sh | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/tests/runtest.sh b/tests/runtest.sh
+index b6eaa7c..84263fb 100644
+--- a/tests/runtest.sh
++++ b/tests/runtest.sh
+@@ -21,6 +21,11 @@ for i in ${TESTS}; do
+     echo "### RUNNING TEST $i"
+     if [[ $AUTOMATED != 0 ]] ; then
+         bash ./runtest.sh
++        if [ $? != 0 ]; then
++            echo "FAIL: $i"
++        else
++            echo "PASS: $i"
++        fi
+     else
+         bash ./runtest.sh || exit 1
+     fi
+-- 
+2.11.0
+

--- a/recipes-security/keyutils/keyutils_1.6.1.bb
+++ b/recipes-security/keyutils/keyutils_1.6.1.bb
@@ -1,0 +1,45 @@
+SUMMARY = "Linux Key Management Utilities"
+DESCRIPTION = "\
+    Utilities to control the kernel key management facility and to provide \
+    a mechanism by which the kernel call back to userspace to get a key \
+    instantiated. \
+    "
+HOMEPAGE = "http://people.redhat.com/dhowells/keyutils"
+SECTION = "base"
+
+LICENSE = "LGPL-2.1-or-later & GPL-2.0-or-later"
+
+LIC_FILES_CHKSUM = "file://LICENCE.GPL;md5=5f6e72824f5da505c1f4a7197f004b45 \
+                    file://LICENCE.LGPL;md5=7d1cacaa3ea752b72ea5e525df54a21f"
+
+inherit siteinfo autotools-brokensep
+
+SRC_URI = "http://people.redhat.com/dhowells/keyutils/${BP}.tar.bz2 \
+           file://keyutils-test-fix-output-format.patch \
+           file://keyutils-fix-error-report-by-adding-default-message.patch \
+           file://fix_library_install_path.patch \
+           "
+
+SRC_URI[md5sum] = "919af7f33576816b423d537f8a8692e8"
+SRC_URI[sha256sum] = "c8b15722ae51d95b9ad76cc6d49a4c2cc19b0c60f72f61fb9bf43eea7cbd64ce"
+
+EXTRA_OEMAKE = "'CFLAGS=${CFLAGS} -Wall' \
+    NO_ARLIB=1 \
+    BINDIR=${base_bindir} \
+    SBINDIR=${base_sbindir} \
+    LIBDIR=${libdir} \
+    USRLIBDIR=${libdir} \
+    INCLUDEDIR=${includedir} \
+    ETCDIR=${sysconfdir} \
+    SHAREDIR=${datadir}/keyutils \
+    MANDIR=${datadir}/man \
+    BUILDFOR=${SITEINFO_BITS}-bit \
+    NO_GLIBC_KEYERR=1 \
+    "
+
+do_install () {
+    install -d ${D}/${libdir}/pkgconfig
+    oe_runmake DESTDIR=${D} install
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This recipe used to live in meta-security by the time of Sumo, but was later moved to meta-oe because it was used all over by several recipes.

Latest commit is `14c7d8a0d7cb843ac8b0d25cc4170fa640ac1295` ("recipes: Update LICENSE variable to use SPDX license
identifiers") from 2022-03-04. Imported without support for ptest.