### PR TITLE
meta: conf: distro: lkft: drop tar.bz2 images

### DIFF
--- a/meta/conf/distro/lkft.conf
+++ b/meta/conf/distro/lkft.conf
@@ -10,7 +10,7 @@ CMDLINE:remove = "quiet"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-generic-mainline"
 MACHINE_HWCODECS:intel-corei7-64 = ""
 MACHINE_HWCODECS:intel-core2-32 = ""
-IMAGE_FSTYPES:remove = "ext4 iso wic wic.bmap wic.gz wic.xz"
+IMAGE_FSTYPES:remove = "ext4 iso wic wic.bmap wic.gz wic.xz tar.bz2"
 IMAGE_FSTYPES:append = " ext4.gz tar.xz"
 
 INHERIT += "image-buildinfo"


### PR DESCRIPTION
No need to build tar.bz2 images since there are already tar.xz images
generated.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>