### PR TITLE
meta: linux: linux-lkft: add gmp-native dependency

### DIFF
--- a/meta/recipes-kernel/linux/linux-lkft.inc
+++ b/meta/recipes-kernel/linux/linux-lkft.inc
@@ -234,6 +234,9 @@ export HOSTLDFLAGS="${BUILD_LDFLAGS}"
 # Makefile:23: *** dtc needs libyaml for DT
 DEPENDS += "libyaml-native"
 
+# With the latest gcc10 plugins, the host tools need gmp support
+DEPENDS += "gmp-native"
+
 DEPENDS += "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
 
 # Automatically depend on lzop/lz4-native if CONFIG_KERNEL_LZO/LZ4 is enabled


### PR DESCRIPTION
With the latest gcc10 plugins, the host tools need gmp support
or the build end up with:

| In file included from /oe/build/tmp-glibc/work/dragonboard_845c-oe-linux/linux-generic-mainline/5.19+gitAUTOINC+c40e8341e3-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.3.0/plugin/include/gcc-plugin.h:28,
|                  from /oe/build/tmp-glibc/work-shared/dragonboard-845c/kernel-source/scripts/gcc-plugins/gcc-common.h:7,
|                  from /oe/build/tmp-glibc/work-shared/dragonboard-845c/kernel-source/scripts/gcc-plugins/stackleak_plugin.c:30:
| /oe/build/tmp-glibc/work/dragonboard_845c-oe-linux/linux-generic-mainline/5.19+gitAUTOINC+c40e8341e3-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.3.0/plugin/include/system.h:698:10: fatal error: gmp.h: No such file or directory
|   698 | #include <gmp.h>
|       |          ^~~~~~~
| compilation terminated.
| make[2]: *** [/oe/build/tmp-glibc/work-shared/dragonboard-845c/kernel-source/scripts/gcc-plugins/Makefile:54: scripts/gcc-plugins/stackleak_plugin.so] Error 1
| make[1]: *** [/oe/build/tmp-glibc/work-shared/dragonboard-845c/kernel-source/scripts/Makefile.build:465: scripts/gcc-plugins] Error 2
| make[1]: *** Waiting for unfinished jobs....
| make: *** [/oe/build/tmp-glibc/work-shared/dragonboard-845c/kernel-source/Makefile:1189: scripts] Error 2
| ERROR: oe_runmake failed

Adding 'gmp-native' to DEPENDS.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>