### PR TITLE
linux-lkft: Set CXXFLAGS for native parts

### DIFF
--- a/meta/recipes-kernel/linux/linux-lkft.inc
+++ b/meta/recipes-kernel/linux/linux-lkft.inc
@@ -229,6 +229,7 @@ DEPENDS += "openssl-native"
 export HOST_EXTRACFLAGS += "-I${STAGING_INCDIR_NATIVE}"
 
 export HOSTCFLAGS="${BUILD_CFLAGS}"
+export HOSTCXXFLAGS="${BUILD_CXXFLAGS}"
 export HOSTLDFLAGS="${BUILD_LDFLAGS}"
 
 # Makefile:23: *** dtc needs libyaml for DT


### PR DESCRIPTION
When building native components in the kernel, some environment variables help in conveying the right information to the right compilation commands. Previously, commit 474dd625386e ("linux-lkft: Set CFLAGS and LDFLAGS for native parts") made sure we had `CFLAGS` and `LDFLAGS` set for these native compilations, but the following error still happened with recent versions of the kernel:
```
  HOSTCXX scripts/gcc-plugins/stackleak_plugin.so
In file included from /oe/build/tmp-glibc/work/dragonboard_410c-oe-linux/linux-generic-stable/5.19+gitAUTOINC+7d0a458e19-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.3.0/plugin/include/gcc-plugin.h:28,
                 from /oe/build/tmp-glibc/work-shared/dragonboard-410c/kernel-source/scripts/gcc-plugins/gcc-common.h:7,
                 from /oe/build/tmp-glibc/work-shared/dragonboard-410c/kernel-source/scripts/gcc-plugins/stackleak_plugin.c:30:
/oe/build/tmp-glibc/work/dragonboard_410c-oe-linux/linux-generic-stable/5.19+gitAUTOINC+7d0a458e19-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/../../lib/aarch64-oe-linux/gcc/aarch64-oe-linux/11.3.0/plugin/include/system.h:698:10: fatal error: gmp.h: No such file or directory
  698 #include <gmp.h>
               ^~~~~~~
compilation terminated.
make[2]: *** [/oe/build/tmp-glibc/work-shared/dragonboard-410c/kernel-source/scripts/gcc-plugins/Makefile:54: scripts/gcc-plugins/stackleak_plugin.so] Error 1
make[1]: *** [/oe/build/tmp-glibc/work-shared/dragonboard-410c/kernel-source/scripts/Makefile.build:466: scripts/gcc-plugins] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [/oe/build/tmp-glibc/work-shared/dragonboard-410c/kernel-source/Makefile:1188: scripts] Error 2
```
Setting `CXXFLAGS` too allows the compilation of `stackleak_plugin.c` to have access to the right include directory.