### PR TITLE
perf: Fix cross-compilation on recent kernels

### DIFF
--- a/meta/recipes-kernel/perf/perf.bbappend
+++ b/meta/recipes-kernel/perf/perf.bbappend
@@ -4,6 +4,7 @@
 # libbpf").
 PERF_SRC += "scripts"
 
+DEPENDS += "python3 python3-setuptools-native"
 RDEPENDS:${PN} += "libcap"
 RDEPENDS:${PN}-python += "libcap"
 RDEPENDS:${PN}-tests += "bash"
@@ -11,3 +12,7 @@ RDEPENDS:${PN}-tests += "bash"
 PACKAGECONFIG[coresight] = "CORESIGHT=1,,opencsd"
 
 PACKAGECONFIG:append = " coresight"
+
+export HOSTCFLAGS = "${BUILD_CFLAGS}"
+export HOSTCXXFLAGS = "${BUILD_CXXFLAGS}"
+export HOSTLDFLAGS = "${BUILD_LDFLAGS}"


### PR DESCRIPTION
Recent kernels made it more apparent a few problems with Perf. One such change is that cross-compilation requires the definition of the following variables:
```
HOSTCFLAGS
HOSTCXXFLAGS
HOSTLDFLAGS
```
They are now set to their corresponding OE equivalent. This is in line with a recent change in the kernel recipes, as the same build mechanism is used throughout.

The other problem involved the lack of setuptools for Python3 when the support for libpython was enabled.