### PR TITLE
meta: packagegroups: lkft-tools: add coreutils

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -17,6 +17,7 @@ RDEPENDS:packagegroup-lkft-tools = "\
 
 SUMMARY:packagegroup-lkft-tools = "Basic tools and libraries for LKFT"
 RDEPENDS:packagegroup-lkft-tools-basics = "\
+    coreutils \
     e2fsprogs \
     e2fsprogs-mke2fs \
     git \


### PR DESCRIPTION
Add package coreutils to packagegroup-lkft-tools, since the binary program split are needed to run sharding.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>