### PR TITLE
linux: kselftests: Reinstall kernel_headers before make'ing install

### DIFF
--- a/meta/recipes-kernel/linux/kselftests.inc
+++ b/meta/recipes-kernel/linux/kselftests.inc
@@ -23,6 +23,10 @@ do_compile:append() {
 }
 
 do_install:append() {
+    # Make sure to install the user space API used by some tests
+    # but not properly declared as a build dependency
+    ${MAKE} -C ${S} ARCH=${ARCH} headers_install
+
     ${MAKE} ${KSELFTESTS_ARGS} install
     chown -R root:root ${D}
     # fixup run_kselftest.sh due to spurious lines starting by "make[1]:"


### PR DESCRIPTION
During the `make install` phase there are binaries that get rebuilt. Because there is a mismatch in the kernel_headers, some of the test programs will fail to find the proper symbols. By making `headers_install` before `install`, we ensure that the headers will be there for any recompilation that may need to occur.