### PR TITLE
packagegroup: Add socat

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -28,6 +28,7 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     net-snmp \
     perf \
     qemu \
+    socat \
     tzdata \
     usbutils \
     xz \


### PR DESCRIPTION
Some network tests require `socat` to run. For example: net.gre_gso.sh from kselftests.

[LKQ-989]