### PR TITLE
packagegroup: Add os-release

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -26,6 +26,7 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     jq \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     net-snmp \
+    os-release \
     perf \
     qemu \
     tzdata \


### PR DESCRIPTION
This adds useful information (like distro and distro version) with very little extra space usage. This information is then picked up by various test harnesses, like test-definitions.