### PR TITLE
netsniff-ng: Call upon dependencies for mausezahn, install all tools

### DIFF
--- a/meta/recipes-support/netsniff-ng/netsniff-ng_0.6.8.bbappend
+++ b/meta/recipes-support/netsniff-ng/netsniff-ng_0.6.8.bbappend
@@ -1,0 +1,11 @@
+DEPENDS = "bison \
+    flex \
+    libcli \
+    libnet \
+    libpcap \
+    ncurses \
+"
+
+do_install() {
+    oe_runmake DESTDIR=${D} install_all
+}


### PR DESCRIPTION
Currently only `netsniff-ng`, the binary itself, is installed, but more tools are available in that repo. In fact, we're after `mausezahn`, which is a required tool for some kselftests.