### PR TITLE
Add sed and choose the right sort

### DIFF
--- a/meta/recipes-core/busybox/busybox/lkft.cfg
+++ b/meta/recipes-core/busybox/busybox/lkft.cfg
@@ -1,0 +1,2 @@
+# Use sort from coreutils
+CONFIG_SORT=n

--- a/meta/recipes-core/busybox/busybox_%.bbappend
+++ b/meta/recipes-core/busybox/busybox_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/busybox:"
+
+SRC_URI += "file://lkft.cfg"

--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -29,6 +29,7 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     os-release \
     perf \
     qemu \
+    sed \
     socat \
     tzdata \
     usbutils \


### PR DESCRIPTION
Add the `sed` binary to the rootfs. For `sort`, two options exist already: Busybox's and coreutils'. The Busybox configuration will deselect `sort` from the build, thus leaving the field open for coreutils' `sort`, which is the one needed for more options.