### PR TITLE
[kirkstone] v4l-utils: Update to 2022-12-30's master

### DIFF
--- a/meta/recipes-multimedia/v4l2apps/v4l-utils_git.bb
+++ b/meta/recipes-multimedia/v4l2apps/v4l-utils_git.bb
@@ -15,10 +15,10 @@ inherit autotools gettext pkgconfig
 PACKAGECONFIG ??= "media-ctl"
 PACKAGECONFIG[media-ctl] = "--enable-v4l-utils,--disable-v4l-utils,,"
 
-PV = "1.20.0+git"
+PV = "1.22.0+git"
 
 SRC_URI = "git://git.linuxtv.org/v4l-utils.git;protocol=https;nobranch=1"
-SRCREV = "5d8c459c1bf9c91779419c3f0c26a9caa30d9d27"
+SRCREV = "ef51009796e75b4880773141805ddb16c9fe1e70"
 
 S = "${WORKDIR}/git"
 B = "${S}"


### PR DESCRIPTION
This is the list of commits from the current version until today's HEAD:
```
5d8c459c v4l2-ctl: recognize compound h264 and fwht control types
3f61e353 configure.ac: autodetect availability of systemd
01f2c6c5 keytable: restrict installation of 50-rc_keymap.conf
cd138c90 cec: improve vendor ID logging
5b3355e3 configure.ac: Resolve GIT_* even if repository is a submodule
fc95aea7 configure.ac: Fix building without libudev
a9555cea Rudimentary support for mi_media_detect_type on FreeBSD.
a20dc92b v4l-utils: switch remote_subtest arrays to vector
bafe32e7 v4l-utils: convert board_list to vector
1d808f1c clang-tidy: use using instead of typedef
a15dfa56 v4l2-compliance: rename stvec to vec_remote_subtests
1b681512 clang-tidy: use auto
a1369a2e clang-tidy: use nullptr
9aa8ee69 remove unused ARRAY_SIZE
8683a3e5 cec-tuner: std::array conversions
d5f30a07 v4l2-utils: turn fb_formats to constexpr array
928c1730 v4l2-ctl: add missing const, use {} instead of memset
51914012 v4l2-ctl: remove unused struct flag_def
9156821c cec-compliance: add Audio System mask to Set Audio Rate
82a21f59 cec: add active sensing test for Audio Rate Control messages
1ab369e8 cec: add invalid operand test for Audio Rate Control messages
65270533 v4l2-dbg: fix control flow problem
b36d9f24 v4l2-compliance: move all vivid controls to v4l2-compliance.h
44c27e50 cec-follower: increase precision of Audio Rate Control active sensing
e617add8 cec-follower: detect the cessation of Audio Rate Control messages
4631ee0a ir-ctl: include timeout in raw IR and parse timeout in pulse-space file
e949a98f utils/libcecutil/cec-log.cpp: report 6 digits of Vendor ID
2735ec27 utils/cec: fix inconsistent Vendor ID reporting
f0c7e3d7 v4l2-ctl: add '--set-edid type=list' support
bf461ab0 cec-compliance: clarify a warning
3ba75420 cec-compliance: use the actual audio_out_delay value
dee1ba88 cec-compliance: improve error message
9438348f mass constexpr conversions
72a981cc v4l-utils: add missing static
8b15be51 v4l-utils: add missing fallthrough
32345f66 cec-compliance: hardcode audio_out_delay to 1 if not set
c768b107 v4l2-compliance: V4L2_PIX_FMT_VP8_FRAME is for stateless decoder
b1c246cc v4l-utils: sync with upstream media_tree master
172709e7 v4l2-ctl: add new control types
d7d42f2c cec-compliance: skip warning if audio_out_delay is 1
c379af4a v4l-utils: sync with media_tree/master
1d4b23f1 cec-compliance: move audio helper functions to cec-test-audio.cpp
57a0264c cec-compliance: move CDC helper functions to cec-test.cpp
c8d617cc cec-follower: emulate features for CEC versions < CEC 2.0
5fc4802a cec: add tests for Give Deck Status message
524ff547 cec-ctl: improve 'Sleep' message in stress test
f5859e9d cec-ctl: min/max-sleep arguments should be double, not unsigned
1d13fcca v4l-utils: patch v4l2-controls.h
d54759c5 v4l-utils: sync with media_tree master
b4a71102 v4l2-compliance: improve request tests
9b245588 contrib/test/test-media: add -setup option
287ce79d v4l2-compliance: fix bad indentation
29a2b3c6 cec: add tests for Deck Control message
6481d9b0 cec: add tests for Deck Play message
bfaf769f cec-compliance: remove Deck Status test
771d9ed0 v4l2-compliance: fix g++-7 compile error
26f9554f cec-compliance/follower: fix type comparison warnings
08617403 cec: add Deck Control wake-up handling tests
04ad17f8 cec: remove redundant struct cec_msg initializations
154a4242 libcecutil/cec-info.cpp: rename Reserved to Backup
150de0ac keytable: ensure BPF IR decoders use correct section name
2e918066 cec-compliance: remove One Touch Record Status test
bf645cbe cec-follower: use log_addr_type to get local device type
99faf623 cec-follower: fix incorrect fallthrough
8639ff89 cec-ctl: report low drive without --verbose
2843330d test-media: add vidtv to the mc target
6daa8876 test-media: drop vidtv from mc, but warn if MC is disabled for DVB
c4e0bd71 cec-ctl: free signal time -> signal free time
42a4dff9 cec-ctl: log signal free time when (show && !verbose)
4bd445e9 cec: expand One Touch Record tests
b2b981ff cec: add One Touch Record Standby tests
eb47c007 ir-ctl: print correct transmitter count
6ffc5248 ir-ctl: Revert "ir-ctl: print correct transmitter count"
7e07a868 cec: expand Timer Programming tests
d7c8faa5 cec-follower: emulate programmed timer recordings
69f694d3 cec-follower: refactoring: split up overly long functions
08bfcfc8 cec-compliance: use send_timer_error for one more test
a4f2e3a6 cec-compliance: add cec-test-tuner-record-timer.cpp
c86aab9c cec-compliance: improve warning about late reply
ac5c0dc4 v4l2-ctl: print specific error upon failure
7952c004 v4l2-ctl: fix bugs found in streaming_set_cap2out
ce02e60b cec-compliance: improve testLostMsgs test
e9976a2e configure.ac: drop printf for GIT_COMMIT_DATE
58f4f974 cec-compliance: wait up to 10s for Inactive Source reply
22466798 cec-compliance: fix broken timer tests
d61d087f remove pointless constructor
787434a7 utils: replace push_back with emplace_back
dbdc3908 v4l-utils: libdvbv5: fix broken my_strlcpy calls
7c1f86e3 v4l2-ctl: update test EDIDs
cd769da3 v4l2-compliance: add 0 check for v4l2_event reserved field
05a468e0 v4l2-compliance: add new test for 32/64 bit time handling
1874b2d0 ir-ctl: increase the size of the buffer used to read raw files
a83bc4f6 v4l-utils: sync with latest media staging tree
63622490 v4l-compliance: re-introduce NON_COHERENT and cache hints tests
5bdf6830 v4l2-compliance: use fail_on_test_val for better fail reports
ae4ccacb test-media: add -E and -W options
d691f76a test-media: configure vimc scaler correctly
7136ae65 test-media: missed one scaler config line
b3c2f609 test-media: add 'date' at beginning and end, show versions
80a766cd test-media: mc should include vidtv
6b32403a test-media: drop vidtv from the 'mc' target
700f5ded test-media: show version info earlier and show cmd args
dfc6a9d5 cec-compliance: fix 'unresponsive' detection
3725b644 cec-compliance: improve confusing message
fb4f059c cec-compliance: fix confusing 'Transient state' message
493af03f v4l2-compliance: check entity function for codecs
1eaf8721 Prepare for 1.22.0 release
68fd71f0 buildsystem: Start v4l-utils 1.23.0 development cycle
9f1d1e0c cec-compliance: wake up remote device if needed
bc91239d configure.ac: Add copy of gnulib visibility.m4
cd810530 bootstrap.sh: Replace which with POSIX compliant command -v
25498973 m4: Update ax_pthread to latest
66769a9d v4l2grab: print the fourcc when libv4l won't handle it
5c0a4206 v4l2grab: accept other formats than RGB24
a0921e28 v4l2grab: optimize conversion routines
1d00c48a v4l2grab: use BT.709 by default on YUV conversion
0a54a039 v4l2grab: pass fmt to the conversion function
24fd9a97 v4l2grab: add support for handling colorspace
9de3fcbd v4l2grab: rework conversion routines to add more YUV formats
a7605300 v4l2grab: add the basic logic to support planar formats
365915aa v4l2grab: add support for YUV 420 planar and semi-planar formats
a13eec2c v4l2grab: add RGB 32 format and variants
76a4f5d3 v4l2grab: don't try to convert formats on raw mode
2d8584da v4l2grab: add a way to explicitly enable raw mode
dbf210ca decode_tm6000: fix compiler warning
1af867ab libdvbv5/dvb-dev-remote.c: fix send_fmt prototype
9d74b9a0 v4l2grab: use an array for format properties
6ead632c v4l2grab: properly implement quantization
731a651f v4l2grab: avoid the risc of having sizeimage == 0
e14b30c5 v4l2-compliance: improve failure message
ce2d59cf v4l2-compliance: add missing return
e401b3ae v4l2-ctl: pass bus_info to mi_get_media_fd()
c960b297 test-media: increase sleep after modprobe vivid to 3
adcb349b v4l2-compliance: show value with 'delta_ms > 10' fail msg
79b4354f v4l2grab: estimate the frame rate
b949cffb v4l2-compliance: Let uvcvideo return -EACCES
f23b3481 v4l2-compliance: relax time32-64 test
d10a7e93 v4l-utils: update to latest media_stage kernel
68d9f463 v4l2-ctl/compliance: add stateless VP9 support
0349bea7 libv4lconvert: HM12 -> NV12_16L16
6e19bb89 v4l-utils: use v4l_getsubopt instead of getsubopt
c01c6f78 sliced-vbi-detect/test.c: drop unused headers
6a080dbc v4l2-compliance: detect no-mmu systems
885804a4 qv4l2: enable the play action on non-streaming radio rx
f0dee8a3 qv4l2: Add capture toggle and close hotkeys to CaptureWin
5ff5635a v4l2-compliance: increase sleeps that are too short
d95200f6 v4l2-compliance: improve select() check in captureBufs()
85ed37cf v4l2-compliance: improve two vivid_ro_ctrl warnings
b22fc9e5 ir-ctl: allow for different gaps to be specified
7acbf135 cec-ctl: show timestamp for events
4251e70b cec-ctl: periodically insert monotonic/wallclock time
6c905930 v4l2-ctl: support edid-decode output as --set-edid input
d4b70174 v4l2-ctl: Operate on output device if specified
9f0eab72 v4l2-utils: Fix incorrect use of fd in streaming_set_cap2out
d18ba0d8 v4l-utils: sync with latest media staging tree
d124ef52 ir-ctl: report ir overflow
e5000e09 Add check for READ ONLY flag
1be688f0 Revert "Add check for READ ONLY flag"
19460651 Add check for READ ONLY flag
40a51ea5 v4l2-compliance: only check function if an MC is present
467102b5 cec-ctl: fix timestamp log for HPD/5V changes
482610be cec-ctl: only generate eob for CEC pin events
ad827fc1 cec-ctl: improve --analyze-pin performance
b429fa7f cec-ctl: show timestamps in microsecond precision
88e5609b cec-ctl: store the wallclock/monotonic clocks every minute
a1f1fdbf qv4l2: fix search/replace mistake in vbi-tab.cpp/h license text
52b4b9f2 v4l2-ctl: allow waiting/polling for multiple events
71bb951d sync-with-kernel.sh: tuner-xc2028-types.h -> xc2028-types.h
6de74333 v4l-utils: sync to latest kernel
16314471 v4l2-compliance: fix G/S_PARM tests for stateful encoders
0efd21a1 v4l-utils: sync-with-kernel
990a063d cec-compliance: make <GET CEC VERSION> mandatory
b9054747 cec-compliance: replace warn by announce if unresponsive
ef8c5223 libv4l2subdev: Fix compilation error by including missing header
8d0c3918 v4l2-ctl: Fix typo in --list-patterns help text
394eee73 v4l2-utils: Change get_(cap_compose|out_crop)_rect() return type to void
33ad0c66 v4l2-utils: read/write full frame from/to file for m2m non codec driver
ae7f823b cec-compliance: don't test if PA is invalid
3b94a0ca v4l-utils: sync with latest kernel headers
9545bc43 v4l2-compliance: detect V4L2_PIX_FMT_HEVC_SLICE
950df5a2 v4l2-ctl: support HEVC controls
2d690bb2 v4l2-compliance/ctl: add dynamic array support
ae731a61 mc_nextgen_test: Display ancillary links
520d2c98 media-info: support ancillary links
429b3b2d v4l2-compliance: Account for ancillary links
015461b5 v4l2-compliance: show ancillary links
a46e57ae v4l2-dbg: drop cap2s(), use v4l2_info_capability() instead
71112d21 rds-ctl: drop cap2s(), use v4l2_info_capability() instead
4cf258c2 v4l2-ctl/rds-ctl: move tuner info helpers to v4l2-info.cpp
bb3a119e v4l-utils: sync with upstream kernel
d73efac6 v4l2-ctl: add support for V4L2_EVENT_CTRL_CH_DIMENSIONS
e13304cb v4l2-ctl: show all dimensions for V4L2_EVENT_CTRL_CH_DIMENSIONS
af4bb7ed v4l2-compliance: check vivid pixel array control behavior
eb967cdd v4l2-compliance: test of vivid's pixel array in requests
89d610f1 xc3028-firmware: fix use-after-free
f50720c4 libdvbv5: fix string overread
2133e11e test-media: check results of cmp in the vicodec tests
bddb4428 v4l2 utils: Support V4L2_PIX_FMT_YUV[AX]32
aeed0077 v4l-utils: sync with upstream media tree
96b18df0 libdvbv5: Fix invalid header file name in Doxygen INPUT
a7611b24 libdvbv5: Fix Doygen deprecation warnings
7034cb79 v4l2-info: add flag V4L2_PIX_FMT_FLAG_SET_CSC
7f560aed v4l-utils: sync with upstream git repo
a8015d2b v4l2-info: move flags2s to v4l2-info.h
1aba21cb v4l2-ctl: print_control should check for array controls
60e1c6ad v4l2-ctl: -C foo -C bar only shows foo
fd544473 v4l2-compliance: support INTEGER and INTEGER64 control arrays
f8648452 test-media: wait longer after rmmod/modprobe if DEBUG_KOBJECT_RELEASE=y
dc29549f cec-follower: add --ignore-standby/view-on options
a588a16a keytable: provide configuration for empty keymap
dce0e3e1 keytable: Convert deprecated libbpf API
d0964d13 v4l2-compliance: support g++ 7.5.0
6269f88d libv4lconvert: Fix v4lconvert_yuv420_to_rgb/bgr24() not taking stride into account
aecfcfcc libv4lconvert: Fix v4lconvert_rgb565_to_rgb/bgr24() not taking stride into account
e8b224d4 libv4lconvert: Fix v4lconvert_nv12_*() not taking stride into account
0c96e7ca libv4lconvert: Fix v4lconvert_nv16_to_yuyv() not taking stride into account
5f28a085 v4l-utils: sync with upstream git repo
96022d88 configure.ac, Makefile.am: Support building without NLS
57c4a4a9 v4l2-tpg.patch: add missing get_random_u8()
af6cc366 libdvbv5: cleanup ASTC service location parsing
b5c8e690 libdvbv5: Read all "other" PIDs for channels
c8afad91 dvbv5-zap: Record all the channel video/audio/other PIDs
6bd5d9c8 v4l-utils: sync with latest upstream git repo
d6be06cf utils: add v4l2-tracer utility
ef064edb v4l2-tracer: add support for most basic controls
2a982f82 libv4lconvert: Fix v4lconvert_grey_to_rgb24 not taking stride into account
523a6588 v4l2grab: fix buffer conversion size
11895130 v4l2grab: fix raw output on mmap
95886309 v4l2grab: validate it the returned image is big enough
e4c47d2d v4l2grab: fix image size calculation for some formats
db225476 v4l2grab: expand video format switch case
fb91262e v4l2grab: allow adding planars with full size
d4ff94a3 v4l2grab: add support for NV16 and NV61
ef510097 v4l2grab: add support for 422P format
```