### PR TITLE
Juno changes stemming from meta-arm

### DIFF
--- a/meta/conf/distro/lkft.conf
+++ b/meta/conf/distro/lkft.conf
@@ -10,7 +10,7 @@ CMDLINE:remove = "quiet"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-generic-mainline"
 MACHINE_HWCODECS:intel-corei7-64 = ""
 MACHINE_HWCODECS:intel-core2-32 = ""
-IMAGE_FSTYPES:remove = "ext4 iso wic wic.bmap wic.gz wic.xz tar.bz2 cpio.gz"
+IMAGE_FSTYPES:remove = "cpio.gz ext4 iso tar.bz2 wic wic.bmap wic.gz wic.xz"
 IMAGE_FSTYPES:append = " ext4.gz tar.xz"
 
 INHERIT += "image-buildinfo"

--- a/meta/conf/distro/lkft.conf
+++ b/meta/conf/distro/lkft.conf
@@ -10,10 +10,14 @@ CMDLINE:remove = "quiet"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-generic-mainline"
 MACHINE_HWCODECS:intel-corei7-64 = ""
 MACHINE_HWCODECS:intel-core2-32 = ""
-IMAGE_FSTYPES:remove = "ext4 iso wic wic.bmap wic.gz wic.xz tar.bz2"
+IMAGE_FSTYPES:remove = "ext4 iso wic wic.bmap wic.gz wic.xz tar.bz2 cpio.gz"
 IMAGE_FSTYPES:append = " ext4.gz tar.xz"
 
 INHERIT += "image-buildinfo"
+
+# For Juno since meta-arm 2023-01-18
+INITRAMFS_IMAGE_BUNDLE:juno = "0"
+KERNEL_IMAGETYPE:juno = "Image"
 
 EXTRA_IMAGECMD:juno:ext4 += " -L rootfs "
 


### PR DESCRIPTION
Recently, meta-arm added a few changes to the way the Juno image is bundled. We cope with this by setting the Image compression (or lack thereof) and the removal of a cpio rootfs, which we don't use; we also disable the creation of an initramfs.