### PR TITLE
packagegroup: lkft-tools: Add ntfs-3g for mount.ntfs

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -28,6 +28,7 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     jq \
     ${@bb.utils.contains("TUNE_ARCH", "arm", "", "numactl", d)} \
     net-snmp \
+    ntfs-3g \
     ntfsprogs \
     os-release \
     perf \


### PR DESCRIPTION
The `ntfsprogs` recipe will create a symlink for

mount.ntfs -> mount.ntfs-3g

but only ship `mount.ntfs` on the `ntfs-3g` package. This adds this package to the root file system, so that tests that find NTFS support can also mount it.

This was found due to an error with LTP Syscalls' chdir01:
```
chdir01.c:56: TINFO: Trying FUSE...
sh: line 1: mount.ntfs: command not found
chdir01.c:56: TBROK: mount.ntfs failed with 32512
```