### PR TITLE
LTP 20230516

### DIFF
--- a/meta-lkft-testsuites/recipes-extended/ltp/ltp_20230516.bb
+++ b/meta-lkft-testsuites/recipes-extended/ltp/ltp_20230516.bb
@@ -24,7 +24,7 @@ TUNE_CCARGS:remove:x86-64 = "-mfpmath=sse"
 
 CFLAGS:append:powerpc64 = " -D__SANE_USERSPACE_TYPES__"
 CFLAGS:append:mipsarchn64 = " -D__SANE_USERSPACE_TYPES__"
-SRCREV = "dd2d61ac1a1e09797a6165f478abd4a9f4f43035"
+SRCREV = "3ebc2dfa85c2445bb68d8c0d66e33c4da1e1b3a7"
 
 SRC_URI = "git://github.com/linux-test-project/ltp.git;branch=master;protocol=https"
 


### PR DESCRIPTION
This updates LTP to the latest version, 20230516.

No changes to the recipe: no patches have been added, same build procedure is used, etc.