### PR TITLE
packagegroup: Add python3-scapy

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -46,4 +46,5 @@ RDEPENDS:packagegroup-lkft-tools-python3 = "\
     python3 \
     python3-misc \
     python3-modules \
+    python3-scapy \
     "


### PR DESCRIPTION
This package is used by kselftests' tc-testing:
```
kselftest tc-testing need  scapy python module.
kselftest: Running tests in tc-testing
TAP version 13
1..1
selftests: tc-testing: tdc.sh
considering category actions
Unable to import the scapy python module.

If not already installed, you may do so with:
pip3 install scapy==2.4.2
```
More info here: https://linaro.atlassian.net/browse/LKQ-926

The package is provided by meta-networking.