### PR TITLE
packagegroup: Drop Perf

### DIFF
--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-testsuites.bb
@@ -14,7 +14,6 @@ RDEPENDS:packagegroup-lkft-testsuites = "\
     libgpiod \
     libgpiod-tools \
     ltp \
-    perf-tests \
     s-suite \
     vdsotest \
     "

--- a/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
+++ b/meta/recipes-samples/packagegroups/packagegroup-lkft-tools.bb
@@ -31,7 +31,6 @@ RDEPENDS:packagegroup-lkft-tools-basics = "\
     ntfs-3g \
     ntfsprogs \
     os-release \
-    perf \
     qemu \
     sed \
     socat \


### PR DESCRIPTION
We have agreed with the kernel community to use the most recent version of Perf on older branches. There is no need to build this on all stable branches.